### PR TITLE
ensure that readdir only encodes an integral number of dirents

### DIFF
--- a/p9/messages.go
+++ b/p9/messages.go
@@ -1651,17 +1651,15 @@ func (r *rreaddir) decode(b *buffer) {
 func (r *rreaddir) encode(b *buffer) {
 	entriesBuf := buffer{}
 	for _, d := range r.Entries {
+		prev := len(entriesBuf.data)
 		d.encode(&entriesBuf)
 		if len(entriesBuf.data) >= int(r.Count) {
+			entriesBuf.data = entriesBuf.data[:prev]
 			break
 		}
 	}
-	if len(entriesBuf.data) < int(r.Count) {
-		r.Count = uint32(len(entriesBuf.data))
-		r.payload = entriesBuf.data
-	} else {
-		r.payload = entriesBuf.data[:r.Count]
-	}
+	r.Count = uint32(len(entriesBuf.data))
+	r.payload = entriesBuf.data
 	b.Write32(uint32(r.Count))
 }
 


### PR DESCRIPTION
the 9p standard requires that readdir respond with an integral
number of dirents. The encoder for readdir could respond with
a partial dirent if adding the full dirent would exceed msize.
The Linux kernel in turn got upset and returned EIO to user mode.

This change fixes the problem and adds a test. At the moment
the change causes a problem in another test but it's late so I'll
look at that tomorrow.

We need to start processing and honoring the offset in a readdir,
but probably *after* we fix Linux.

Should we be vendoring p9? dep ensure? What's the call here?