### PR TITLE
Remove allocate extension.

### DIFF
--- a/localfs/localfs.go
+++ b/localfs/localfs.go
@@ -293,8 +293,3 @@ func (l *Local) Flush() error {
 func (l *Local) Renamed(parent p9.File, newName string) {
 	l.path = path.Join(parent.(*Local).path, newName)
 }
-
-// Allocate implements p9.File.Allocate.
-func (l *Local) Allocate(mode p9.AllocateMode, offset, length uint64) error {
-	return syscall.Fallocate(int(l.file.Fd()), mode.ToLinux(), int64(offset), int64(length))
-}

--- a/p9/client_file.go
+++ b/p9/client_file.go
@@ -169,18 +169,6 @@ func (c *clientFile) SetAttr(valid SetAttrMask, attr SetAttr) error {
 	return c.client.sendRecv(&tsetattr{fid: c.fid, Valid: valid, SetAttr: attr}, &rsetattr{})
 }
 
-// Allocate implements File.Allocate.
-func (c *clientFile) Allocate(mode AllocateMode, offset, length uint64) error {
-	if atomic.LoadUint32(&c.closed) != 0 {
-		return syscall.EBADF
-	}
-	if !versionSupportsTallocate(c.client.version) {
-		return syscall.EOPNOTSUPP
-	}
-
-	return c.client.sendRecv(&tallocate{fid: c.fid, Mode: mode, Offset: offset, Length: length}, &rallocate{})
-}
-
 // Remove implements File.Remove.
 //
 // N.B. This method is no longer part of the file interface and should be

--- a/p9/file.go
+++ b/p9/file.go
@@ -87,10 +87,6 @@ type File interface {
 	// On the server, SetAttr has a write concurrency guarantee.
 	SetAttr(valid SetAttrMask, attr SetAttr) error
 
-	// Allocate allows the caller to directly manipulate the allocated disk space
-	// for the file. See fallocate(2) for more details.
-	Allocate(mode AllocateMode, offset, length uint64) error
-
 	// Close is called when all references are dropped on the server side,
 	// and Close should be called by the client to drop all references.
 	//

--- a/p9/handlers.go
+++ b/p9/handlers.go
@@ -868,40 +868,6 @@ func (t *tsetattr) handle(cs *connState) message {
 }
 
 // handle implements handler.handle.
-func (t *tallocate) handle(cs *connState) message {
-	// Lookup the fid.
-	ref, ok := cs.LookupFID(t.fid)
-	if !ok {
-		return newErr(syscall.EBADF)
-	}
-	defer ref.DecRef()
-
-	if err := ref.safelyWrite(func() error {
-		// Has it been opened already?
-		openFlags, opened := ref.OpenFlags()
-		if !opened {
-			return syscall.EINVAL
-		}
-
-		// Can it be written? Check permissions.
-		if openFlags&OpenFlagsModeMask == ReadOnly {
-			return syscall.EBADF
-		}
-
-		// We don't allow allocate on files that have been deleted.
-		if ref.isDeleted() {
-			return syscall.EINVAL
-		}
-
-		return ref.file.Allocate(t.Mode, t.Offset, t.Length)
-	}); err != nil {
-		return newErr(err)
-	}
-
-	return &rallocate{}
-}
-
-// handle implements handler.handle.
 func (t *txattrwalk) handle(cs *connState) message {
 	// Lookup the fid.
 	ref, ok := cs.LookupFID(t.fid)

--- a/p9/messages.go
+++ b/p9/messages.go
@@ -1392,63 +1392,6 @@ func (r *rsetattr) String() string {
 	return fmt.Sprintf("Rsetattr{}")
 }
 
-// tallocate is an allocate request. This is an extension to 9P protocol, not
-// present in the 9P2000.L standard.
-type tallocate struct {
-	fid    fid
-	Mode   AllocateMode
-	Offset uint64
-	Length uint64
-}
-
-// decode implements encoder.decode.
-func (t *tallocate) decode(b *buffer) {
-	t.fid = b.ReadFID()
-	t.Mode.decode(b)
-	t.Offset = b.Read64()
-	t.Length = b.Read64()
-}
-
-// encode implements encoder.encode.
-func (t *tallocate) encode(b *buffer) {
-	b.WriteFID(t.fid)
-	t.Mode.encode(b)
-	b.Write64(t.Offset)
-	b.Write64(t.Length)
-}
-
-// Type implements message.Type.
-func (*tallocate) typ() msgType {
-	return msgTallocate
-}
-
-// String implements fmt.Stringer.
-func (t *tallocate) String() string {
-	return fmt.Sprintf("Tallocate{FID: %d, Offset: %d, Length: %d}", t.fid, t.Offset, t.Length)
-}
-
-// rallocate is an allocate response.
-type rallocate struct {
-}
-
-// decode implements encoder.decode.
-func (*rallocate) decode(b *buffer) {
-}
-
-// encode implements encoder.encode.
-func (*rallocate) encode(b *buffer) {
-}
-
-// Type implements message.Type.
-func (*rallocate) typ() msgType {
-	return msgRallocate
-}
-
-// String implements fmt.Stringer.
-func (r *rallocate) String() string {
-	return fmt.Sprintf("Rallocate{}")
-}
-
 // txattrwalk walks extended attributes.
 type txattrwalk struct {
 	// fid is the fid to check for attributes.
@@ -2252,6 +2195,4 @@ func init() {
 	msgRegistry.register(msgRumknod, func() message { return &rumknod{} })
 	msgRegistry.register(msgTusymlink, func() message { return &tusymlink{} })
 	msgRegistry.register(msgRusymlink, func() message { return &rusymlink{} })
-	msgRegistry.register(msgTallocate, func() message { return &tallocate{} })
-	msgRegistry.register(msgRallocate, func() message { return &rallocate{} })
 }

--- a/p9/p9.go
+++ b/p9/p9.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 // Debug can be assigned to log.Printf to print messages received and sent.
@@ -362,8 +360,6 @@ const (
 	msgRusymlink            = 135
 	msgTlconnect            = 136
 	msgRlconnect            = 137
-	msgTallocate            = 138
-	msgRallocate            = 139
 )
 
 // QIDType represents the file type for QIDs.
@@ -1045,81 +1041,4 @@ func (d *Dirent) encode(b *buffer) {
 	b.Write64(d.Offset)
 	b.WriteQIDType(d.Type)
 	b.WriteString(d.Name)
-}
-
-// AllocateMode are possible modes to p9.File.Allocate().
-type AllocateMode struct {
-	KeepSize      bool
-	PunchHole     bool
-	NoHideStale   bool
-	CollapseRange bool
-	ZeroRange     bool
-	InsertRange   bool
-	Unshare       bool
-}
-
-// ToLinux converts to a value compatible with fallocate(2)'s mode.
-func (a *AllocateMode) ToLinux() uint32 {
-	rv := uint32(0)
-	if a.KeepSize {
-		rv |= unix.FALLOC_FL_KEEP_SIZE
-	}
-	if a.PunchHole {
-		rv |= unix.FALLOC_FL_PUNCH_HOLE
-	}
-	if a.NoHideStale {
-		rv |= unix.FALLOC_FL_NO_HIDE_STALE
-	}
-	if a.CollapseRange {
-		rv |= unix.FALLOC_FL_COLLAPSE_RANGE
-	}
-	if a.ZeroRange {
-		rv |= unix.FALLOC_FL_ZERO_RANGE
-	}
-	if a.InsertRange {
-		rv |= unix.FALLOC_FL_INSERT_RANGE
-	}
-	if a.Unshare {
-		rv |= unix.FALLOC_FL_UNSHARE_RANGE
-	}
-	return rv
-}
-
-// decode implements encoder.decode.
-func (a *AllocateMode) decode(b *buffer) {
-	mask := b.Read32()
-	a.KeepSize = mask&0x01 != 0
-	a.PunchHole = mask&0x02 != 0
-	a.NoHideStale = mask&0x04 != 0
-	a.CollapseRange = mask&0x08 != 0
-	a.ZeroRange = mask&0x10 != 0
-	a.InsertRange = mask&0x20 != 0
-	a.Unshare = mask&0x40 != 0
-}
-
-// encode implements encoder.encode.
-func (a *AllocateMode) encode(b *buffer) {
-	mask := uint32(0)
-	if a.KeepSize {
-		mask |= 0x01
-	}
-	if a.PunchHole {
-		mask |= 0x02
-	}
-	if a.NoHideStale {
-		mask |= 0x04
-	}
-	if a.CollapseRange {
-		mask |= 0x08
-	}
-	if a.ZeroRange {
-		mask |= 0x10
-	}
-	if a.InsertRange {
-		mask |= 0x20
-	}
-	if a.Unshare {
-		mask |= 0x40
-	}
-	b.Write32(mask)
 }

--- a/p9/version.go
+++ b/p9/version.go
@@ -128,8 +128,3 @@ func versionSupportsTucreation(v uint32) bool {
 func VersionSupportsMultiUser(v uint32) bool {
 	return v >= 6
 }
-
-// versionSupportsTallocate returns true if version v supports Allocate().
-func versionSupportsTallocate(v uint32) bool {
-	return v >= 7
-}

--- a/unimplfs/unimplfs.go
+++ b/unimplfs/unimplfs.go
@@ -143,8 +143,3 @@ func (NoopFile) Flush() error {
 
 // Renamed implements p9.File.Renamed.
 func (NoopFile) Renamed(parent p9.File, newName string) {}
-
-// Allocate implements p9.File.Allocate.
-func (NoopFile) Allocate(mode p9.AllocateMode, offset, length uint64) error {
-	return syscall.ENOSYS
-}


### PR DESCRIPTION
This is a gVisor-specific extension that allowed calling fallocate on a
FID. No client other than gVisor and this library support it.

cc @djdv

Signed-off-by: Chris Koch <chrisko@google.com>