### PR TITLE
WIP:Change server so it takes io.ReadCloser and io.WriteCloser

### DIFF
--- a/p9/client_test.go
+++ b/p9/client_test.go
@@ -32,7 +32,7 @@ func TestVersion(t *testing.T) {
 
 	// Create a new server and client.
 	s := NewServer(nil)
-	go s.Handle(serverSocket)
+	go s.Handle(serverSocket, serverSocket)
 
 	// NewClient does a Tversion exchange, so this is our test for success.
 	c, err := NewClient(clientSocket, 1024*1024 /* 1M message size */, HighestVersionString())


### PR DESCRIPTION
There are several situations where a server needs to take two
different files, and they may not be a net.Conn, e.g. from a
pipe or stdin/stdout (both of these are occuring in the cpu
command).

This is pretty standard for 9p servers:
you can see it in the Linux 9p fs with its use
of rfdno and wfdno. Plan 9, similarly, allowed for use of
two different fds for servers.

Change the Handle and underlying transport code to use an
io.ReadCloser and io.WriteCloser for T and R messages
respectively.

This builds, but won't test yet:
client_test.go:21:2: cannot find package "github.com/hugelgupf/socketpair" in any of:
	/home/rminnich/go/src/github.com/hugelgupf/socketpair (from $GOROOT)
	/home/rminnich/gopath/src/github.com/hugelgupf/socketpair (from $GOPATH)
FAIL	github.com/hugelgupf/p9/p9 [setup failed]

Not sure of the correct way to fix this.

I need this for the cpu command.