### PR TITLE
local_server: add support for unix domain sockets

### DIFF
--- a/cmd/local_server/local_server.go
+++ b/cmd/local_server/local_server.go
@@ -34,6 +34,7 @@ import (
 var (
 	verbose = flag.Bool("v", false, "verbose logging")
 	root    = flag.String("root", "/", "root dir of file system to expose")
+	unix    = flag.Bool("unix", false, "use unix domain socket instead of TCP")
 )
 
 func main() {
@@ -42,12 +43,19 @@ func main() {
 		p9.Debug = log.Printf
 	}
 
+	var network string
+	if *unix {
+		network = "unix"
+	} else {
+		network = "tcp"
+	}
+
 	if len(flag.Args()) != 1 {
 		log.Fatalf("usage: %s <bind-addr>", os.Args[0])
 	}
 
 	// Bind and listen on the socket.
-	serverSocket, err := net.Listen("tcp", flag.Args()[0])
+	serverSocket, err := net.Listen(network, flag.Args()[0])
 	if err != nil {
 		log.Fatalf("err binding: %v", err)
 	}


### PR DESCRIPTION
This add support for binding `local_server` to UNIX domain socket, e.g. to restrict server usage to a specific system user / group. The Linux kernel 9p implementation does support transport over unix domain sockets as well. To verify that this change works correctly using the Linux implementation:

```
$ local_server -root . -unix /tmp/9p
$ mount -t 9p /tmp/9p /media/9pfs/ -o trans=unix
$ ls /media/9pfs/
…
```