### PR TITLE
localfs: implement RenameAt

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -239,6 +239,14 @@ func (l *Local) Link(target p9.File, newname string) error {
 	return os.Link(target.(*Local).path, path.Join(l.path, newname))
 }
 
+// RenameAt implements p9.File.RenameAt.
+func (l *Local) RenameAt(oldName string, newDir p9.File, newName string) error {
+	oldPath := path.Join(l.path, oldName)
+	newPath := path.Join(newDir.(*Local).path, newName)
+
+	return os.Rename(oldPath, newPath)
+}
+
 // Readlink implements p9.File.Readlink.
 //
 // Not properly implemented.


### PR DESCRIPTION
My 9P knowledge is a bit rusty and I am not too familiar with the P9 API. Nonetheless, I came up with the following implementation of the `RenameAt` function for `localfs`. IMHO this implementation is complete as is and I did some preliminary tests with the 9p Linux implementation which confirm this hypothesis. If I missed anything let me know.