### PR TITLE
p9: introduce sessions

### DIFF
--- a/p9/messages.go
+++ b/p9/messages.go
@@ -2007,6 +2007,9 @@ type msgFactory struct {
 	cache  chan message
 }
 
+// msgVersionRegistry only allows tversion messages.
+var msgVersionRegistry registry
+
 // msgDotLRegistry indexes all 9P2000.L(.Google.N) message factories by type.
 var msgDotLRegistry registry
 
@@ -2145,4 +2148,7 @@ func init() {
 	msgDotLRegistry.register(msgRumknod, func() message { return &rumknod{} })
 	msgDotLRegistry.register(msgTusymlink, func() message { return &tusymlink{} })
 	msgDotLRegistry.register(msgRusymlink, func() message { return &rusymlink{} })
+
+	msgVersionRegistry.register(msgTversion, func() message { return &tversion{} })
+	msgVersionRegistry.register(msgRversion, func() message { return &rversion{} })
 }

--- a/p9/p9.go
+++ b/p9/p9.go
@@ -352,7 +352,7 @@ const (
 	msgTremove      msgType = 122
 	msgRremove      msgType = 123
 	msgTflushf      msgType = 124
-	msgRflushf      msgType = 125
+	msgRflushf      msgType = 124
 	msgTwalkgetattr msgType = 126
 	msgRwalkgetattr msgType = 127
 	msgTucreate     msgType = 128


### PR DESCRIPTION
This is a pre-cursor to supporting 9P2000, where some messages may
overlap. Sessions should allow us to change the version & message
registry.

9P2000 spec / Plan 9 man page for version(5):

"If the server does not understand the client's version string, it
should respond with an Rversion message (not Rerror) with the version
string the 7 characters "unknown"."

"A successful version request initializes the connection. All
outstanding I/O on the connection is aborted; all active fids are freed
(clunked) automatically. The set of messages between version requests
is called a session."

Signed-off-by: Chris Koch <chrisko@google.com>