### PR TITLE
p9: remove unnecessary allocations when using sync.Pool

### DIFF
--- a/p9/transport.go
+++ b/p9/transport.go
@@ -69,14 +69,17 @@ const (
 var dataPool = sync.Pool{
 	New: func() interface{} {
 		// These buffers are used for decoding without a payload.
-		return make([]byte, initialBufferLength)
+		// We need to return a pointer to avoid unnecessary allocations
+		// (see https://staticcheck.io/docs/checks#SA6002).
+		b := make([]byte, initialBufferLength)
+		return &b
 	},
 }
 
 // send sends the given message over the socket.
 func send(l ulog.Logger, w io.Writer, tag tag, m message) error {
-	data := dataPool.Get().([]byte)
-	dataBuf := buffer{data: data[:0]}
+	data := dataPool.Get().(*[]byte)
+	dataBuf := buffer{data: (*data)[:0]}
 
 	l.Printf("send [w %p] [Tag %06d] %s", w, tag, m)
 
@@ -112,7 +115,7 @@ func send(l ulog.Logger, w io.Writer, tag tag, m message) error {
 	}
 
 	// All set.
-	dataPool.Put(dataBuf.data)
+	dataPool.Put(&dataBuf.data)
 	return nil
 }
 
@@ -167,12 +170,29 @@ func recv(l ulog.Logger, r io.Reader, msize uint32, lookup lookupTagAndType) (ta
 
 	// Not yet initialized.
 	var dataBuf buffer
+	var vecs vecnet.Buffers
+
+	appendBuffer := func(size int) *[]byte {
+		// Pull a data buffer from the pool.
+		datap := dataPool.Get().(*[]byte)
+		data := *datap
+		if size > len(data) {
+			// Create a larger data buffer.
+			data = make([]byte, size)
+			datap = &data
+		} else {
+			// Limit the data buffer.
+			data = data[:size]
+		}
+		dataBuf = buffer{data: data}
+		vecs = append(vecs, data)
+		return datap
+	}
 
 	// Read the rest of the payload.
 	//
 	// This requires some special care to ensure that the vectors all line
 	// up the way they should. We do this to minimize copying data around.
-	var vecs vecnet.Buffers
 	if payloader, ok := m.(payloader); ok {
 		fixedSize := payloader.FixedSize()
 
@@ -186,22 +206,8 @@ func recv(l ulog.Logger, r io.Reader, msize uint32, lookup lookupTagAndType) (ta
 		}
 
 		if fixedSize != 0 {
-			// Pull a data buffer from the pool.
-			data := dataPool.Get().([]byte)
-			if int(fixedSize) > len(data) {
-				// Create a larger data buffer, ensuring
-				// sufficient capicity for the message.
-				data = make([]byte, fixedSize)
-				defer dataPool.Put(data)
-				dataBuf = buffer{data: data}
-				vecs = append(vecs, data)
-			} else {
-				// Limit the data buffer, and make sure it
-				// gets filled before the payload buffer.
-				defer dataPool.Put(data)
-				dataBuf = buffer{data: data[:fixedSize]}
-				vecs = append(vecs, data[:fixedSize])
-			}
+			datap := appendBuffer(int(fixedSize))
+			defer dataPool.Put(datap)
 		}
 
 		// Include the payload.
@@ -214,20 +220,8 @@ func recv(l ulog.Logger, r io.Reader, msize uint32, lookup lookupTagAndType) (ta
 			vecs = append(vecs, p)
 		}
 	} else if remaining != 0 {
-		// Pull a data buffer from the pool.
-		data := dataPool.Get().([]byte)
-		if int(remaining) > len(data) {
-			// Create a larger data buffer.
-			data = make([]byte, remaining)
-			defer dataPool.Put(data)
-			dataBuf = buffer{data: data}
-			vecs = append(vecs, data)
-		} else {
-			// Limit the data buffer.
-			defer dataPool.Put(data)
-			dataBuf = buffer{data: data[:remaining]}
-			vecs = append(vecs, data[:remaining])
-		}
+		datap := appendBuffer(int(remaining))
+		defer dataPool.Put(datap)
 	}
 
 	if len(vecs) > 0 {


### PR DESCRIPTION
This issue was found by staticcheck.
Per https://staticcheck.io/docs/checks#SA6002, we must store in the pool
a pointer to the slice (instead of storing the slice directly) to avoid
extra allocations.

The send/receive benchmark shows we avoid 2 allocations:
```
name           old time/op    new time/op    delta
SendRecvTCP-4    36.0µs ± 5%    36.4µs ± 2%    ~     (p=0.548 n=5+5)

name           old alloc/op   new alloc/op   delta
SendRecvTCP-4    5.37kB ± 5%    5.38kB ± 1%    ~     (p=0.421 n=5+5)

name           old allocs/op  new allocs/op  delta
SendRecvTCP-4      62.0 ± 0%      60.0 ± 0%  -3.23%  (p=0.008 n=5+5)
```

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>