### PR TITLE
9p localfs server: set iounit to 0 on open and creat

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -178,7 +178,7 @@ func (l *Local) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
 	}
 	l.file = f
 
-	return qid, 4096, nil
+	return qid, 0, nil
 }
 
 // ReadAt implements p9.File.ReadAt.
@@ -205,7 +205,7 @@ func (l *Local) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, 
 		l2.Close()
 		return nil, p9.QID{}, 0, err
 	}
-	return l2, qid, 4096, nil
+	return l2, qid, 0, nil
 }
 
 // Mkdir implements p9.File.Mkdir.


### PR DESCRIPTION
If the iounit is set to 0, the client (linux kernel) will use up to msize-sizeof(p9header) sized requests for read and write, leading to dramatically better performance.

On an atomicpi, this boosts performance by almost 4x: time dd if=/9/bin/x86_64-linux-gnu-lto-dump-11 of=/dev/null bs=128K 189+1 records in
189+1 records out
24879104 bytes (25 MB, 24 MiB) copied, 0.418601 s, 59.4 MB/s

Without this change, bandwidth was stuck at about 13 MB/s.

With this change, performance is comparable to the LLNL DIOD implementation in C, and about 2x the performance of rust-9p.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>