### PR TITLE
p9: handlers: support extended attributes

### DIFF
--- a/fsimpl/templatefs/readonly.go
+++ b/fsimpl/templatefs/readonly.go
@@ -94,6 +94,16 @@ func (ReadOnlyFile) Flush() error {
 	return nil
 }
 
+// XattrWalk implements p9.FIle.XattrWalk
+func (ReadOnlyFile) XattrWalk(attr string) (p9.File, uint64, error) {
+	return nil, 0, linux.ENOSYS
+}
+
+// XattrCreate implements p9.File.XattrCreate
+func (ReadOnlyFile) XattrCreate(attr string, size uint64, flags uint32) error {
+	return linux.ENOSYS
+}
+
 // ReadOnlyDir denies any directory and file operations with EROFS
 //
 // Those operations are Create, Mkdir, Symlink, Link, Mknod, RenameAt,
@@ -158,6 +168,16 @@ func (ReadOnlyDir) Remove() error {
 // Rename implements p9.File.Rename.
 func (ReadOnlyDir) Rename(directory p9.File, name string) error {
 	return linux.EROFS
+}
+
+// XattrWalk implements p9.FIle.XattrWalk
+func (ReadOnlyDir) XattrWalk(attr string) (p9.File, uint64, error) {
+	return nil, 0, linux.ENOSYS
+}
+
+// XattrCreate implements p9.File.XattrCreate
+func (ReadOnlyDir) XattrCreate(attr string, size uint64, flags uint32) error {
+	return linux.ENOSYS
 }
 
 // IsDir returns EISDIR for ReadAt and WriteAt.

--- a/fsimpl/templatefs/unimplfs.go
+++ b/fsimpl/templatefs/unimplfs.go
@@ -150,6 +150,16 @@ func (NoopFile) Readlink() (string, error) {
 	return "", linux.ENOSYS
 }
 
+// XattrWalk implements p9.FIle.XattrWalk
+func (NoopFile) XattrWalk(attr string) (p9.File, uint64, error) {
+	return nil, 0, linux.ENOSYS
+}
+
+// XattrCreate implements p9.File.XattrCreate
+func (NoopFile) XattrCreate(attr string, size uint64, flags uint32) error {
+	return linux.ENOSYS
+}
+
 type NotLockable struct{}
 
 // Lock implements p9.File.Lock.

--- a/p9/file.go
+++ b/p9/file.go
@@ -127,6 +127,22 @@ type File interface {
 	// for additional requirements regarding lazy path resolution.
 	WriteAt(p []byte, offset int64) (int, error)
 
+	// XattrWalk walks an extended attribute, returns a file representing
+	// that attribute and the size of the attribute value. The returned file
+	// can be used in ReadAt() to get the actual attribute value.
+	//
+	// On the server, XattrWalk has a read concurrency guarantee.
+	XattrWalk(attr string) (File, uint64, error)
+
+	// XattrCreate creates an extended attribute on the file, and when it's
+	// done, the current File should refers to the extended attribute, not the
+	// file itself. The file can be later used in WriteAt() to write the
+	// attribute value.
+	// flags are implementation-specific, but are generally Linux setxattr(2) flags.
+	//
+	// On the server, XattrCreate has a write concurrency guarantee.
+	XattrCreate(attr string, size uint64, flags uint32) error
+
 	// FSync syncs this node. Open must be called first.
 	//
 	// On the server, FSync has a read concurrency guarantee.


### PR DESCRIPTION
This commit adds 2 methods to the File interface:

* XattrWalk
* XattrCreate

These 2 methods can be used to implement the handlers for txattrwalk and txattrcreate.

This PR is an alternative implementation for https://github.com/hugelgupf/p9/pull/66 since I feel that #66 may not be idiomatic. An actual implementation of the 2 methods above is in https://github.com/Lencerf/cpu/commit/1849ded7d7d14a5dae1963da5e6ba834daf53983 . Suggestions are much appreciated!

cc @rminnich @brho