### PR TITLE
add stubs for xattr on windows

### DIFF
--- a/fsimpl/xattr/xattr_windows.go
+++ b/fsimpl/xattr/xattr_windows.go
@@ -1,0 +1,11 @@
+package xattr
+
+import "github.com/hugelgupf/p9/internal/linux"
+
+func List(p string) ([]string, error) {
+	return nil, linux.ENOSYS
+}
+
+func Get(p string, attr string) ([]byte, error) {
+	return nil, linux.ENOSYS
+}


### PR DESCRIPTION
What should the error be?
There are no xattrs on windows, so possibly just
return an indication they do not exist?