### PR TITLE
Use Go 1.13 error conventions and forward `File.Close` errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hugelgupf/p9
 
-go 1.18
+go 1.20
 
 require (
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714

--- a/p9/handlers.go
+++ b/p9/handlers.go
@@ -156,8 +156,8 @@ func clunkHandleXattr(cs *connState, t *tclunk) message {
 func (t *tclunk) handle(cs *connState) message {
 	cerr := clunkHandleXattr(cs, t)
 
-	if !cs.DeleteFID(t.fid) {
-		return newErr(linux.EBADF)
+	if err := cs.DeleteFID(t.fid); err != nil {
+		return newErr(err)
 	}
 	if cerr != nil {
 		return cerr
@@ -214,8 +214,8 @@ func (t *tremove) handle(cs *connState) message {
 	// "It is correct to consider remove to be a clunk with the side effect
 	// of removing the file if permissions allow."
 	// https://swtch.com/plan9port/man/man9/remove.html
-	if !cs.DeleteFID(t.fid) {
-		return newErr(linux.EBADF)
+	if fidErr := cs.DeleteFID(t.fid); fidErr != nil {
+		return newErr(fidErr)
 	}
 	if err != nil {
 		return newErr(err)


### PR DESCRIPTION
Split [this commit](https://github.com/hugelgupf/p9/commit/f71411b12038ad39630f19a50efa35fae71ba43f) into 2, and changed `DecRef` from the previous PR.
Instead of using [`fmt.Errorf` with 2 `%w` verbs](https://github.com/hugelgupf/p9/blob/f71411b12038ad39630f19a50efa35fae71ba43f/p9/server.go#L244), it uses a [slice of errors with `errors.Join`](https://github.com/djdv/p9/blob/064705a20c0b11c9c7a84a67d4b39a122abbbf71/p9/server.go#L227-L255).
Not sure which one makes more sense. Both would require Go 1.20.
If bumping the toolchain is a problem we can use `fmt.Errorf` with a single `%w` and stringify the secondary error.

---

Other [chunks from the fork](https://github.com/hugelgupf/p9/compare/main...djdv:p9:fork) that might have stuff worth incorporating:

A range of various linting: https://github.com/hugelgupf/p9/compare/2fdc9667a4d384c310557b525cedf9aa966d0858%5E...7d74b92b80b0895328d5f2e4171e63af8c3406c1
I didn't measure it but I wonder if the struct alignment one has any (marginal) performance gains or not.
Likewise with the calls to `Sprintf` when logging is enabled.

Using the provided `ulog` rather than a global `log`:
https://github.com/hugelgupf/p9/commit/0230d8b3dd0a493aa16d3ccd3d8c4cc4cb06b3ea

A fix for https://github.com/hugelgupf/p9/issues/56:
https://github.com/hugelgupf/p9/commit/399d4c868da138e67a5c0a70d51d844c69c26b09
There's an inconsistency when calling `Client.Walk(nil)` and `instance.Walk(nil)`, the former will return an empty QID list, but the latter can't without this patch.
And a ["why" comment](https://github.com/hugelgupf/p9/commit/399d4c868da138e67a5c0a70d51d844c69c26b09#diff-f48f8fdb94b53dfb16d467d7734a437e0a82315ee21c507277f73777ef59384fL1109-R1110) in there which I provided what I assume is the answer.

Edit:
I also have something external that [wraps the `Server` and provides a `Shutdown` method](https://github.com/djdv/go-filesystem-utils/blob/b8808eb479eee21c069e9b0afddbf8dae05a0591/internal/net/9p/server.go) similar to how `net/http` has. 
Some parts of that may or may not be useful.