### PR TITLE
staticfs: tests & fixes against Linux kernel usage

### DIFF
--- a/fsimpl/readdir/readdir.go
+++ b/fsimpl/readdir/readdir.go
@@ -16,17 +16,31 @@ func min(a, b uint64) uint64 {
 // Repeated calls for the same directory must be made with the same names and
 // types.
 func Readdir(offset uint64, count uint32, names []string, qids map[string]p9.QID) (p9.Dirents, error) {
+	// The value of offset can be implementation defined, as long as it
+	// follows the doc:
+	//
+	// "On subsequent calls, offset is the offset returned
+	// in the last directory entry of the previous call."
+	//
+	// We choose the entry index.
 	if offset >= uint64(len(names)) {
 		return nil, nil
 	}
 
 	var dirents []p9.Dirent
+
+	// count is actually the number of _bytes_ requested by the client.
+	//
+	// p9.File.Readdir implementation can return way more entries, and p9
+	// server will marshal the bytes and make it fit in `count` bytes.
 	end := int(min(offset+uint64(count), uint64(len(names))))
 	for i, name := range names[offset:end] {
 		dirents = append(dirents, p9.Dirent{
-			QID:    qids[name],
-			Type:   qids[name].Type,
-			Offset: offset + uint64(i),
+			QID:  qids[name],
+			Type: qids[name].Type,
+			// "On subsequent calls, offset is the offset returned
+			// in the last directory entry of the previous call."
+			Offset: offset + uint64(i) + 1,
 			Name:   name,
 		})
 	}

--- a/fsimpl/readdir/readdir.go
+++ b/fsimpl/readdir/readdir.go
@@ -1,0 +1,34 @@
+package readdir
+
+import (
+	"github.com/hugelgupf/p9/p9"
+)
+
+func min(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Readdir can be used to implement p9.File.Readdir for static file systems.
+//
+// Repeated calls for the same directory must be made with the same names and
+// types.
+func Readdir(offset uint64, count uint32, names []string, qids map[string]p9.QID) (p9.Dirents, error) {
+	if offset >= uint64(len(names)) {
+		return nil, nil
+	}
+
+	var dirents []p9.Dirent
+	end := int(min(offset+uint64(count), uint64(len(names))))
+	for i, name := range names[offset:end] {
+		dirents = append(dirents, p9.Dirent{
+			QID:    qids[name],
+			Type:   qids[name].Type,
+			Offset: offset + uint64(i),
+			Name:   name,
+		})
+	}
+	return dirents, nil
+}

--- a/fsimpl/staticfs/staticfs.go
+++ b/fsimpl/staticfs/staticfs.go
@@ -108,7 +108,7 @@ type dir struct {
 
 // Open implements p9.File.Open.
 func (d *dir) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
-	if mode == p9.ReadOnly {
+	if mode.Mode() == p9.ReadOnly {
 		return d.qid, 4096, nil
 	}
 	return p9.QID{}, 0, linux.EROFS
@@ -183,7 +183,7 @@ func (f *file) Walk(names []string) ([]p9.QID, p9.File, error) {
 
 // Open implements p9.File.Open.
 func (f *file) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
-	if mode == p9.ReadOnly {
+	if mode.Mode() == p9.ReadOnly {
 		return f.qid, 4096, nil
 	}
 	return p9.QID{}, 0, linux.EROFS

--- a/fsimpl/staticfs/staticfs_integration_test.go
+++ b/fsimpl/staticfs/staticfs_integration_test.go
@@ -1,0 +1,85 @@
+//go:build !race && linux
+// +build !race,linux
+
+package staticfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hugelgupf/p9/fsimpl/test/rovmtests"
+	"github.com/hugelgupf/p9/fsimpl/test/vmdriver"
+	"github.com/hugelgupf/p9/p9"
+	"github.com/hugelgupf/vmtest"
+	"github.com/hugelgupf/vmtest/qemu"
+	"github.com/u-root/u-root/pkg/uroot"
+	"github.com/u-root/uio/ulog/ulogtest"
+)
+
+// Test that contents match when using Linux client.
+func TestLinuxClient(t *testing.T) {
+	serverSocket, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("err binding: %v", err)
+	}
+	defer serverSocket.Close()
+	serverPort := serverSocket.Addr().(*net.TCPAddr).Port
+
+	attacher, err := New(
+		WithFile("foo.txt", "barbarbar"),
+		WithFile("baz.txt", "barbarbarbar"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := rovmtests.Expectations{
+		Dirs: []rovmtests.Dir{
+			{Path: "", Members: []string{"foo.txt", "baz.txt"}},
+		},
+		Files: []rovmtests.File{
+			{Path: "foo.txt", Content: "barbarbar"},
+			{Path: "baz.txt", Content: "barbarbarbar"},
+		},
+	}
+	dir := t.TempDir()
+	wantB, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "want.json"), wantB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the server.
+	s := p9.NewServer(attacher, p9.WithServerLogger(ulogtest.Logger{TB: t}))
+	go s.Serve(serverSocket)
+
+	// Run the read tests from fsimpl/test/rovmtests.
+	vmtest.RunGoTestsInVM(t, []string{"github.com/hugelgupf/p9/fsimpl/test/rovmtests"}, &vmtest.UrootFSOptions{
+		BuildOpts: uroot.Opts{
+			Commands: uroot.BusyBoxCmds(
+				"github.com/u-root/u-root/cmds/core/dhclient",
+			),
+			ExtraFiles: []string{
+				fmt.Sprintf("%s:etc/want.json", filepath.Join(dir, "want.json")),
+			},
+		},
+		VMOptions: vmtest.VMOptions{
+			QEMUOpts: []qemu.Fn{
+				qemu.WithAppendKernel(fmt.Sprintf("P9_PORT=%d P9_TARGET=192.168.0.2", serverPort)),
+				// 192.168.0.0/24
+				vmdriver.HostNetwork(&net.IPNet{
+					IP:   net.IP{192, 168, 0, 0},
+					Mask: net.CIDRMask(24, 32),
+				}),
+				qemu.WithVMTimeout(30 * time.Second),
+			},
+		},
+	})
+}

--- a/fsimpl/staticfs/staticfs_test.go
+++ b/fsimpl/staticfs/staticfs_test.go
@@ -15,8 +15,6 @@
 package staticfs
 
 import (
-	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/hugelgupf/p9/fsimpl/test"
@@ -40,52 +38,17 @@ func TestFilesMatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := attacher.Attach()
-	if err != nil {
-		t.Fatalf("Failed to attach to %v: %v", attacher, err)
-	}
-
-	// Make sure Readdir lists the files we want to find.
-	if _, _, err := root.Open(p9.ReadOnly); err != nil {
-		t.Fatalf("Open(%v) = %v, want nil", root, err)
-	}
-	dirents, err := root.Readdir(0, 2)
-	if err != nil {
-		t.Fatalf("Readdir(%v) = %v, want nil", root, err)
-	}
-	if dirents.Find("foo.txt") == nil {
-		t.Errorf("Readdir(%v) = %v, does not contain foo.txt", root, dirents)
-	}
-	if dirents.Find("baz.txt") == nil {
-		t.Errorf("Readdir(%v) = %v, does not contain baz.txt", root, dirents)
-	}
-
-	files := map[string]string{
-		"foo.txt": "barbarbar",
-		"baz.txt": "barbarbarbar",
-	}
-	for name, wantCon := range files {
-		// Let's make sure the file content matches, at least twice.
-		_, f, err := root.Walk([]string{name})
-		if err != nil {
-			t.Fatalf("Walk(%s) = %v, want nil", name, err)
-		}
-		if _, _, err := f.Open(p9.ReadOnly); err != nil {
-			t.Fatalf("Open(%v) = %v, want nil", f, err)
-		}
-
-		for i := 0; i < 2; i++ {
-			con, err := ioutil.ReadAll(io.NewSectionReader(f, 0, 30))
-			if err != nil {
-				t.Fatalf("%d ReadAll(%v) = %v, want nil", i, f, err)
-			}
-			if got := string(con); got != wantCon {
-				t.Fatalf("%d ReadAll(%v) = %v, want %v", i, f, got, wantCon)
-			}
-		}
-
-		if err := f.Close(); err != nil {
-			t.Errorf("Close(%v) = %v, want nil", f, err)
-		}
-	}
+	test.TestReadOnlyFS(t, attacher,
+		test.WithFile("foo.txt", "barbarbar", p9.Attr{
+			Mode:      p9.ModeRegular | 0666,
+			Size:      9,
+			BlockSize: 4096,
+		}),
+		test.WithFile("baz.txt", "barbarbarbar", p9.Attr{
+			Mode:      p9.ModeRegular | 0666,
+			Size:      12,
+			BlockSize: 4096,
+		}),
+		test.WithDir("", "foo.txt", "baz.txt"),
+	)
 }

--- a/fsimpl/test/filetest.go
+++ b/fsimpl/test/filetest.go
@@ -131,22 +131,22 @@ func testDirContents(t *testing.T, root p9.File, path string, d dir) {
 	}
 
 	var dirents []p9.Dirent
-	var names []string
 	offset := uint64(0)
 	for {
-		d, err := f.Readdir(offset, 1)
+		d, err := f.Readdir(offset, 1000)
 		if len(d) == 0 || err == io.EOF {
 			break
 		}
 		if err != nil {
 			t.Fatalf("Readdir: %v", err)
 		}
-		if len(d) > 1 {
-			t.Fatalf("Readdir returned %d entries, expected 1", len(d))
-		}
 		dirents = append(dirents, d...)
-		names = append(names, d[0].Name)
-		offset += 1
+		offset = d[len(d)-1].Offset
+	}
+
+	var names []string
+	for _, entry := range dirents {
+		names = append(names, entry.Name)
 	}
 
 	slices.Sort(d.members)

--- a/fsimpl/test/rovmtests/deps_test.go
+++ b/fsimpl/test/rovmtests/deps_test.go
@@ -1,0 +1,12 @@
+//go:build tools
+// +build tools
+
+package rovmtests_test
+
+// List u-root commands that need to be in go.mod & go.sum to be buildable as
+// dependencies. This way, they aren't eliminated by `go mod tidy`.
+//
+// But obviously aren't actually importable, since they are main packages.
+import (
+	_ "github.com/u-root/u-root/cmds/core/dhclient"
+)

--- a/fsimpl/test/rovmtests/expectations.go
+++ b/fsimpl/test/rovmtests/expectations.go
@@ -1,0 +1,22 @@
+package rovmtests
+
+type Dir struct {
+	Path    string
+	Members []string
+}
+
+type File struct {
+	Path    string
+	Content string
+}
+
+type Symlink struct {
+	Path   string
+	Target string
+}
+
+type Expectations struct {
+	Dirs     []Dir
+	Files    []File
+	Symlinks []Symlink
+}

--- a/fsimpl/test/rovmtests/ro_linux_test.go
+++ b/fsimpl/test/rovmtests/ro_linux_test.go
@@ -1,0 +1,97 @@
+// Package rovmtests_test uses the Linux kernel client to mount a 9P file
+// system for reading and performs tests on that file system.
+package rovmtests_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hugelgupf/p9/fsimpl/test/rovmtests"
+	"github.com/hugelgupf/vmtest/guest"
+	"github.com/u-root/u-root/pkg/mount"
+	"github.com/u-root/u-root/pkg/sh"
+	"golang.org/x/exp/slices"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getuid() == 0 {
+		if err := sh.RunWithLogs("dhclient", "-ipv6=false"); err != nil {
+			log.Fatalf("could not configure network for tests: %v", err)
+		}
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestMatchContents(t *testing.T) {
+	guest.SkipIfNotInVM(t)
+
+	targetDir := "/target"
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(targetDir)
+
+	mp, err := mount.Mount(os.Getenv("P9_TARGET"), targetDir, "9p", fmt.Sprintf("trans=tcp,msize=4096,port=%s", os.Getenv("P9_PORT")), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mp.Unmount(0)
+
+	wantBytes, err := os.ReadFile("/etc/want.json")
+	if err != nil {
+		t.Fatalf("Could not find expectations: %v", err)
+	}
+	var want rovmtests.Expectations
+	if err := json.Unmarshal(wantBytes, &want); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range want.Dirs {
+		t.Run(fmt.Sprintf("dir-%s", dir.Path), func(t *testing.T) {
+			dirEntries, err := os.ReadDir(filepath.Join(targetDir, dir.Path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var names []string
+			for _, entry := range dirEntries {
+				names = append(names, entry.Name())
+			}
+			slices.Sort(names)
+			slices.Sort(dir.Members)
+			if !slices.Equal(names, dir.Members) {
+				t.Fatalf("Readdir = %v, want %v", names, dir.Members)
+			}
+		})
+	}
+
+	for _, file := range want.Files {
+		t.Run(fmt.Sprintf("file-%s", file.Path), func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(targetDir, file.Path))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := string(content); got != file.Content {
+				t.Fatalf("Readfile = %s, want %s", got, file.Content)
+			}
+		})
+	}
+
+	for _, symlink := range want.Symlinks {
+		t.Run(fmt.Sprintf("symlink-%s", symlink.Path), func(t *testing.T) {
+			target, err := os.Readlink(filepath.Join(targetDir, symlink.Path))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if target != symlink.Target {
+				t.Fatalf("Readlink = %s, want %s", target, symlink.Target)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hugelgupf/vmtest v0.0.0-20230810222836-f8c8e381617c
 	github.com/u-root/u-root v0.11.1-0.20230807200058-f87ad7ccb594
 	github.com/u-root/uio v0.0.0-20230305220412-3e8cd9d6bf63
+	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad
 	golang.org/x/sys v0.11.0
 	google.golang.org/grpc v1.53.0
 )
@@ -31,7 +32,6 @@ require (
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
-	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/p9/transport.go
+++ b/p9/transport.go
@@ -81,10 +81,10 @@ func send(l ulog.Logger, w io.Writer, tag tag, m message) error {
 	data := dataPool.Get().(*[]byte)
 	dataBuf := buffer{data: (*data)[:0]}
 
-	l.Printf("send [w %p] [Tag %06d] %s", w, tag, m)
-
 	// Encode the message. The buffer will grow automatically.
 	m.encode(&dataBuf)
+
+	l.Printf("send [w %p] [Tag %06d] %s", w, tag, m)
 
 	// Get our vectors to send.
 	var hdr [headerLength]byte


### PR DESCRIPTION
* tests staticfs against Linux kernel client
* actually make staticfs work with Linux: ignore higher-order OpenFlags
* fixes Readdir implementation of staticfs, makes it available independently
* log outgoing 9P messages after encoding, as message may be modified by the encoder