### PR TITLE
templatefs: make ReadOnlyFile and ReadOnlyDir more usable

### DIFF
--- a/fsimpl/staticfs/staticfs.go
+++ b/fsimpl/staticfs/staticfs.go
@@ -95,16 +95,14 @@ func (statfs) StatFS() (p9.FSStat, error) {
 type dir struct {
 	statfs
 	p9.DefaultWalkGetAttr
-	templatefs.NotSymlinkFile
 	templatefs.ReadOnlyDir
-	templatefs.IsDir
 	templatefs.NilCloser
-	templatefs.NoopRenamed
-	templatefs.NotLockable
 
 	qid p9.QID
 	a   *attacher
 }
+
+var _ p9.File = &dir{}
 
 // Open implements p9.File.Open.
 func (d *dir) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
@@ -163,15 +161,13 @@ type file struct {
 	p9.DefaultWalkGetAttr
 	templatefs.ReadOnlyFile
 	templatefs.NilCloser
-	templatefs.NotDirectoryFile
-	templatefs.NotSymlinkFile
-	templatefs.NoopRenamed
-	templatefs.NotLockable
 
 	*strings.Reader
 
 	qid p9.QID
 }
+
+var _ p9.File = &file{}
 
 // Walk implements p9.File.Walk.
 func (f *file) Walk(names []string) ([]p9.QID, p9.File, error) {

--- a/fsimpl/templatefs/unimplfs.go
+++ b/fsimpl/templatefs/unimplfs.go
@@ -35,18 +35,35 @@ func (NilCloser) Close() error {
 	return nil
 }
 
+// NilSyncer returns nil for FSync.
+type NilSyncer struct{}
+
+// FSync implements p9.File.FSync.
+func (NilSyncer) FSync() error {
+	return nil
+}
+
 // NoopRenamed does nothing when the file is renamed.
 type NoopRenamed struct{}
 
 // Renamed implements p9.File.Renamed.
 func (NoopRenamed) Renamed(parent p9.File, newName string) {}
 
-// NoopFile is a p9.File that returns ENOSYS for every method.
-type NoopFile struct {
+// NotImplementedFile is a p9.File that returns ENOSYS for every listed method.
+//
+// Compatible with NoopRenamed, NilCloser, and NilSyncer.
+type NotImplementedFile struct {
 	p9.DefaultWalkGetAttr
-	NilCloser
-	NoopRenamed
 	NotLockable
+	XattrUnimplemented
+}
+
+// NoopFile is a p9.File with every method unimplemented.
+type NoopFile struct {
+	NotImplementedFile
+	NilCloser
+	NilSyncer
+	NoopRenamed
 }
 
 var (
@@ -54,119 +71,117 @@ var (
 )
 
 // Walk implements p9.File.Walk.
-func (NoopFile) Walk(names []string) ([]p9.QID, p9.File, error) {
+func (NotImplementedFile) Walk(names []string) ([]p9.QID, p9.File, error) {
 	return nil, nil, linux.ENOSYS
 }
 
 // StatFS implements p9.File.StatFS.
 //
 // Not implemented.
-func (NoopFile) StatFS() (p9.FSStat, error) {
+func (NotImplementedFile) StatFS() (p9.FSStat, error) {
 	return p9.FSStat{}, linux.ENOSYS
 }
 
 // Open implements p9.File.Open.
-func (NoopFile) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
+func (NotImplementedFile) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
 	return p9.QID{}, 0, linux.ENOSYS
 }
 
 // ReadAt implements p9.File.ReadAt.
-func (NoopFile) ReadAt(p []byte, offset int64) (int, error) {
+func (NotImplementedFile) ReadAt(p []byte, offset int64) (int, error) {
 	return 0, linux.ENOSYS
 }
 
 // GetAttr implements p9.File.GetAttr.
-func (NoopFile) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+func (NotImplementedFile) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
 	return p9.QID{}, p9.AttrMask{}, p9.Attr{}, linux.ENOSYS
 }
 
 // SetAttr implements p9.File.SetAttr.
-func (NoopFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
+func (NotImplementedFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 	return linux.ENOSYS
 }
 
 // Remove implements p9.File.Remove.
-func (NoopFile) Remove() error {
+func (NotImplementedFile) Remove() error {
 	return linux.ENOSYS
 }
 
 // Rename implements p9.File.Rename.
-func (NoopFile) Rename(directory p9.File, name string) error {
-	return linux.ENOSYS
-}
-
-// FSync implements p9.File.FSync.
-func (NoopFile) FSync() error {
+func (NotImplementedFile) Rename(directory p9.File, name string) error {
 	return linux.ENOSYS
 }
 
 // WriteAt implements p9.File.WriteAt.
-func (NoopFile) WriteAt(p []byte, offset int64) (int, error) {
+func (NotImplementedFile) WriteAt(p []byte, offset int64) (int, error) {
 	return 0, linux.ENOSYS
 }
 
 // Create implements p9.File.Create.
-func (NoopFile) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.File, p9.QID, uint32, error) {
+func (NotImplementedFile) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.File, p9.QID, uint32, error) {
 	return nil, p9.QID{}, 0, linux.ENOSYS
 }
 
 // Mkdir implements p9.File.Mkdir.
-func (NoopFile) Mkdir(name string, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.QID, error) {
+func (NotImplementedFile) Mkdir(name string, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.QID, error) {
 	return p9.QID{}, linux.ENOSYS
 }
 
 // Symlink implements p9.File.Symlink.
-func (NoopFile) Symlink(oldname string, newname string, _ p9.UID, _ p9.GID) (p9.QID, error) {
+func (NotImplementedFile) Symlink(oldname string, newname string, _ p9.UID, _ p9.GID) (p9.QID, error) {
 	return p9.QID{}, linux.ENOSYS
 }
 
 // Link implements p9.File.Link.
-func (NoopFile) Link(target p9.File, newname string) error {
+func (NotImplementedFile) Link(target p9.File, newname string) error {
 	return linux.ENOSYS
 }
 
 // Mknod implements p9.File.Mknod.
-func (NoopFile) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, _ p9.UID, _ p9.GID) (p9.QID, error) {
+func (NotImplementedFile) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, _ p9.UID, _ p9.GID) (p9.QID, error) {
 	return p9.QID{}, linux.ENOSYS
 }
 
 // RenameAt implements p9.File.RenameAt.
-func (NoopFile) RenameAt(oldname string, newdir p9.File, newname string) error {
+func (NotImplementedFile) RenameAt(oldname string, newdir p9.File, newname string) error {
 	return linux.ENOSYS
 }
 
 // UnlinkAt implements p9.File.UnlinkAt.
-func (NoopFile) UnlinkAt(name string, flags uint32) error {
+func (NotImplementedFile) UnlinkAt(name string, flags uint32) error {
 	return linux.ENOSYS
 }
 
 // Readdir implements p9.File.Readdir.
-func (NoopFile) Readdir(offset uint64, count uint32) (p9.Dirents, error) {
+func (NotImplementedFile) Readdir(offset uint64, count uint32) (p9.Dirents, error) {
 	return nil, linux.ENOSYS
 }
 
 // Readlink implements p9.File.Readlink.
-func (NoopFile) Readlink() (string, error) {
+func (NotImplementedFile) Readlink() (string, error) {
 	return "", linux.ENOSYS
 }
 
+// XattrUnimplemented implements Xattr methods returning ENOSYS.
+type XattrUnimplemented struct{}
+
 // SetXattr implements p9.File.SetXattr.
-func (NoopFile) SetXattr(attr string, data []byte, flags p9.XattrFlags) error {
+func (XattrUnimplemented) SetXattr(attr string, data []byte, flags p9.XattrFlags) error {
 	return linux.ENOSYS
 }
 
 // GetXattr implements p9.File.GetXattr.
-func (NoopFile) GetXattr(attr string) ([]byte, error) {
+func (XattrUnimplemented) GetXattr(attr string) ([]byte, error) {
 	return nil, linux.ENOSYS
 }
 
 // ListXattrs implements p9.File.ListXattrs.
-func (NoopFile) ListXattrs() ([]string, error) {
+func (XattrUnimplemented) ListXattrs() ([]string, error) {
 	return nil, linux.ENOSYS
 }
 
 // RemoveXattr implements p9.File.RemoveXattr.
-func (NoopFile) RemoveXattr(attr string) error {
+func (XattrUnimplemented) RemoveXattr(attr string) error {
 	return linux.ENOSYS
 }
 


### PR DESCRIPTION
ReadOnlyFile and ReadOnlyDir now each implement default denials for every method except the ones that the "user" trying to implement such files really has to implement -- Open, Walk, GetAttr, Close for both, and ReadAt for the file, Readdir for the dir.