### PR TITLE
composefs: never return the mounted p9.File

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -156,9 +156,10 @@ func (l *Local) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
 // Close implements p9.File.Close.
 func (l *Local) Close() error {
 	if l.file != nil {
-		err := l.file.Close()
-		l.file = nil
-		return err
+		// We don't set l.file = nil, as Close is called by servers
+		// only in Clunk. Clunk should release the last (direct)
+		// reference to this file.
+		return l.file.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
Always return a clone, so the "original" mounted File remains avaiable for Walks.

@djdv your comment got me thinking (sorry I should have waited a bit before merging, heh). I made the original change because one of the tests in composefs had this issue:

```
=== RUN   TestFilesMatch/file-localfs/somefile                                                                                                                             
    filetest.go:179: Walk(localfs/somefile) failed: stat /tmp/TestFilesMatch3250066062/001: use of closed file
```

But really, that was an issue with composefs. Close should mean the p9.File is not used anymore, so any `l.file` gymnastics should be unnecessary. (Maybe this will change with whatever we do for #62, since we do retain references to parents, but this is how it currently is.)