### PR TITLE
Use existing `ulog`s rather than global std `log`

### DIFF
--- a/linux/errors.go
+++ b/linux/errors.go
@@ -2,7 +2,6 @@ package linux
 
 import (
 	"errors"
-	"log"
 	"os"
 )
 
@@ -35,8 +34,5 @@ func ExtractErrno(err error) Errno {
 	}
 
 	// Default case.
-	//
-	// TODO: give the ability to turn this off.
-	log.Printf("unknown error: %v", err)
 	return EIO
 }

--- a/p9/client.go
+++ b/p9/client.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"sync"
 
 	"github.com/hugelgupf/p9/linux"
@@ -193,11 +192,11 @@ func NewClient(conn io.ReadWriteCloser, o ...ClientOpt) (*Client, error) {
 		baseVersion, version, ok := parseVersion(rversion.Version)
 		if !ok {
 			// The server gave us a bad version. We return a generically worrisome error.
-			log.Printf("server returned bad version string %q", rversion.Version)
+			c.log.Printf("server returned bad version string %q", rversion.Version)
 			return nil, ErrBadVersionString
 		}
 		if baseVersion != version9P2000L {
-			log.Printf("server returned unsupported base version %q (version %q)", baseVersion, rversion.Version)
+			c.log.Printf("server returned unsupported base version %q (version %q)", baseVersion, rversion.Version)
 			return nil, ErrBadVersionString
 		}
 		c.version = version
@@ -218,7 +217,7 @@ func (c *Client) handleOne() {
 
 		// Not expecting this message?
 		if resp == nil {
-			log.Printf("client received unexpected tag %v, ignoring", t)
+			c.log.Printf("client received unexpected tag %v, ignoring", t)
 			return nil, ErrUnexpectedTag
 		}
 

--- a/p9/client_file.go
+++ b/p9/client_file.go
@@ -17,7 +17,6 @@ package p9
 import (
 	"fmt"
 	"io"
-	"log"
 	"runtime"
 	"sync/atomic"
 
@@ -245,7 +244,6 @@ func (c *clientFile) Close() error {
 	if err := c.client.sendRecv(&tclunk{fid: c.fid}, &rclunk{}); err != nil {
 		// If an error occurred, we toss away the fid. This isn't ideal,
 		// but I'm not sure what else makes sense in this context.
-		log.Printf("Tclunk failed, losing fid %v: %v", c.fid, err)
 		return err
 	}
 

--- a/p9/server.go
+++ b/p9/server.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"runtime/debug"
 	"sync"
@@ -505,7 +504,7 @@ func (cs *connState) handleRequest() {
 			rec := recover()
 
 			// Include a useful log message.
-			log.Printf("panic in handler - %v: %s", rec, debug.Stack())
+			cs.server.log.Printf("panic in handler - %v: %s", rec, debug.Stack())
 
 			// Wrap in an EFAULT error; we don't really have a
 			// better way to describe this kind of error. It will


### PR DESCRIPTION
`Server` and `Client` have a default value for their log, which can be overridden by callers of their constructors. If none are provided, nothing should be printed, if one is, it should be used for these messages, rather than using the global `log`.

`clientFile` does not need to log a failure from `Close` at all, the caller will receive the error value directly, and the context added to the message, is already implied by the protocol.