### PR TITLE
Implement UnlinkAt in localfs

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -18,6 +18,7 @@ package localfs
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/hugelgupf/p9/fsimpl/templatefs"
 	"github.com/hugelgupf/p9/internal"
@@ -267,7 +268,7 @@ func (l *Local) Renamed(parent p9.File, newName string) {
 // SetAttr implements p9.File.SetAttr.
 func (l *Local) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 	// When truncate(2) is called on Linux, Linux will try to set time & size. Fake it. Sorry.
-	supported := p9.SetAttrMask{Size: true, MTime: true, CTime: true}
+	supported := p9.SetAttrMask{Size: true, MTime: true, CTime: true, ATime: true}
 	if !valid.IsSubsetOf(supported) {
 		return linux.ENOSYS
 	}
@@ -278,4 +279,13 @@ func (l *Local) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
 		return os.Truncate(l.path, int64(attr.Size))
 	}
 	return nil
+}
+
+// UnlinkAt implements p9.File.UnlinkAt
+func (l *Local) UnlinkAt(name string, flags uint32) error {
+	// Construct the full path
+	fullPath := filepath.Join(l.path, name)
+
+	// Remove the file or directory
+	return os.Remove(fullPath)
 }

--- a/fsimpl/localfs/localfs_test.go
+++ b/fsimpl/localfs/localfs_test.go
@@ -30,4 +30,6 @@ func TestLocalFS(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	test.TestFile(t, Attacher(tempDir))
+	test.TestReadOnlyFS(t, Attacher(tempDir))
+	test.TestReadWriteFS(t, Attacher(tempDir))
 }


### PR DESCRIPTION
Fix #86 

This is my attempt at UnlinkAt as discussed in #86 .

I also added ATime in the ignored but valid fields of SetAttr, as without it, `touch` can't create a file over 9P.

I hope the tests are OK. I added TestReadOnlyFS to localfs' test suite, and created a TestReadWriteFS to try out the new UnlinkAt implementation.

Please let me know if you need me to change anything.

I also tested the changes from the client side in another piece of software I'm writing, and p9ufs behaves the same way as if the changes were done directly by through the kernel file API.