### PR TITLE
p9ufs: clarify that :port is required

### DIFF
--- a/cmd/p9ufs/p9ufs.go
+++ b/cmd/p9ufs/p9ufs.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	if len(flag.Args()) != 1 {
-		log.Fatalf("usage: %s <bind-addr>", os.Args[0])
+		log.Fatalf("usage: %s <bind-addr:port>", os.Args[0])
 	}
 
 	// Bind and listen on the socket.


### PR DESCRIPTION
```
$ p9ufs 127.0.0.1
2025/04/02 10:20:51 err binding: listen tcp: address 127.0.0.1: missing port in address
```