### PR TITLE
localfs: `File.Create` compliance

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -205,7 +205,7 @@ func (l *Local) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, 
 	newName := path.Join(l.path, name)
 	f, err := os.OpenFile(newName, int(mode)|os.O_CREATE|os.O_EXCL, os.FileMode(permissions))
 	if err != nil {
-		return nil, p9.QID{}, 0, err
+		return nil, p9.QID{}, 0, translateError(err)
 	}
 
 	l2 := &Local{path: newName, file: f}

--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -60,6 +60,7 @@ type Local struct {
 
 	path string
 	file *os.File
+	directoryPage
 }
 
 var (

--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -16,6 +16,8 @@
 package localfs
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -289,4 +291,15 @@ func (l *Local) UnlinkAt(name string, flags uint32) error {
 
 	// Remove the file or directory
 	return os.Remove(fullPath)
+}
+
+func translateError(err error) error {
+	switch {
+	case errors.Is(err, fs.ErrExist):
+		return linux.EEXIST
+	case errors.Is(err, fs.ErrNotExist):
+		return linux.ENOENT
+	default:
+		return linux.EIO
+	}
 }

--- a/fsimpl/localfs/readdir.go
+++ b/fsimpl/localfs/readdir.go
@@ -1,50 +1,163 @@
 package localfs
 
 import (
+	"errors"
 	"io"
 	"path"
 
+	"github.com/hugelgupf/p9/linux"
 	"github.com/hugelgupf/p9/p9"
+)
+
+type directoryPage struct {
+	overflow     []string
+	next         uint64
+	biggestEntry *uint64
+}
+
+const (
+	qidSize         = 13 // qid[13]
+	offsetSize      = 8  // offset[8]
+	typeSize        = 1  // type[1]
+	sringHeaderSize = 2  // length prefix for name[s]
+	minDirentSize   = qidSize + offsetSize +
+		typeSize + sringHeaderSize
+	minimumNameLen = 1
 )
 
 // Readdir implements p9.File.Readdir.
 func (l *Local) Readdir(offset uint64, count uint32) (p9.Dirents, error) {
-	var (
-		p9Ents = make([]p9.Dirent, 0)
-		cursor = uint64(0)
-	)
-
-	for len(p9Ents) < int(count) {
-		singleEnt, err := l.file.Readdirnames(1)
-
-		if err == io.EOF {
-			return p9Ents, nil
-		} else if err != nil {
+	if count < minDirentSize+minimumNameLen {
+		return nil, linux.EINVAL
+	}
+	chunkSize, err := l.getChunkSize(offset, count)
+	if err != nil {
+		return nil, err
+	}
+	if rewindDir := offset == 0 &&
+		l.next != 0; rewindDir {
+		if err := l.rewindDir(); err != nil {
 			return nil, err
 		}
-
-		// we consumed an entry
-		cursor++
-
-		// cursor \in (offset, offset+count)
-		if cursor < offset || cursor > offset+uint64(count) {
-			continue
-		}
-
-		name := singleEnt[0]
-
-		localEnt := Local{path: path.Join(l.path, name)}
-		qid, _, err := localEnt.info()
-		if err != nil {
+	}
+	var (
+		p9Ents p9.Dirents
+		next   = l.next
+		total  uint32
+	)
+	for {
+		names, lastChunk, err := l.getNextNames(chunkSize)
+		if len(names) == 0 ||
+			err != nil {
 			return p9Ents, err
 		}
-		p9Ents = append(p9Ents, p9.Dirent{
-			QID:    qid,
-			Type:   qid.Type,
-			Name:   name,
-			Offset: cursor,
-		})
+		entries := make(p9.Dirents, len(names))
+		for i, name := range names {
+			size := p9.DirentSize(name)
+			total += size
+			if total > count {
+				if len(p9Ents) == 0 {
+					return nil, linux.EINVAL // `count` too small to fit first entry.
+				}
+				l.next = next
+				l.overflow = names[i:]
+				return p9Ents, nil
+			}
+			var (
+				qid      p9.QID
+				localEnt = Local{path: path.Join(l.path, name)}
+			)
+			qid, _, err := localEnt.info()
+			if err != nil {
+				l.next = next
+				l.overflow = names[i:]
+				return p9Ents, err
+			}
+			next += uint64(size)
+			entries[i] = p9.Dirent{
+				QID:    qid,
+				Type:   qid.Type,
+				Name:   name,
+				Offset: next,
+			}
+		}
+		l.overflow = nil
+		l.next = entries[len(entries)-1].Offset
+		p9Ents = append(p9Ents, entries...)
+		if !lastChunk {
+			remainder := count - uint32(total)
+			if chunkSize, err = l.estimateChunkSize(remainder); err != nil {
+				return nil, err
+			}
+		}
 	}
+}
 
-	return p9Ents, nil
+func (l *Local) getChunkSize(offset uint64, count uint32) (int, error) {
+	if offset == 0 {
+		return 1, nil // "Peek" is a common enough request.
+	}
+	return l.estimateChunkSize(count)
+}
+
+func (l *Local) rewindDir() error {
+	const dirOffset, whence = 0, io.SeekStart
+	_, err := l.file.Seek(dirOffset, whence)
+	if err == nil {
+		l.next = 0
+		l.overflow = nil
+	}
+	return err
+}
+
+func (l *Local) estimateChunkSize(count uint32) (int, error) {
+	if l.biggestEntry == nil { // TODO: abstract better.
+		var maxNameSize uint32
+		if stat, err := l.StatFS(); err == nil {
+			if maxNameSize = stat.NameLength; maxNameSize == 0 {
+				maxNameSize = 255 // Fallback; Common value.
+			}
+		} else {
+			if !errors.Is(err, linux.ENOSYS) {
+				return -1, err
+			}
+			maxNameSize = 255
+		}
+		biggestEntry := direntSize(int(maxNameSize))
+		l.biggestEntry = &biggestEntry
+	}
+	estimate := min(
+		max(
+			uint64(count)/(*l.biggestEntry),
+			1, // At least 1.
+		),
+		256, // At most 256.
+	)
+	return int(estimate), nil
+}
+
+// direntSize computes the 9P2000.L wire size for a dirent.
+func direntSize(nameLen int) uint64 {
+	return uint64(minDirentSize + nameLen)
+}
+
+func (l *Local) getNextNames(count int) ([]string, bool, error) {
+	names := l.overflow
+	if len(names) != 0 {
+		return names, false, nil
+	}
+	var (
+		err       error
+		lastChunk bool
+	)
+	if names, err = l.file.Readdirnames(count); err != nil {
+		if err != io.EOF {
+			return nil, false, err
+		}
+		lastChunk = true
+	}
+	if count <= 0 { // Error will be `nil` (not [io.EOF]);
+		lastChunk = true // set flag via `n`.
+	}
+	return names, lastChunk, nil
 }

--- a/fsimpl/test/filetest.go
+++ b/fsimpl/test/filetest.go
@@ -252,7 +252,7 @@ func readdir(dir p9.File) (p9.Dirents, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Readdir(dir) = %v, want nil", err)
 	}
-	return dirents, nil
+	return dirents, dirCopy.Close()
 }
 
 func testWalkSelf(t *testing.T, root p9.File) {

--- a/fsimpl/test/filetest.go
+++ b/fsimpl/test/filetest.go
@@ -17,7 +17,6 @@ package test
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -133,20 +132,10 @@ func testDirContents(t *testing.T, root p9.File, path string, d dir) {
 		t.Fatalf("Open = %v", err)
 	}
 
-	var dirents []p9.Dirent
-	offset := uint64(0)
-	for {
-		d, err := f.Readdir(offset, 1000)
-		if len(d) == 0 || err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Readdir: %v", err)
-		}
-		dirents = append(dirents, d...)
-		offset = d[len(d)-1].Offset
+	dirents, err := p9.ReadDir(f)
+	if err != nil {
+		t.Fatalf("Readdir: %v", err)
 	}
-
 	var names []string
 	for _, entry := range dirents {
 		names = append(names, entry.Name)
@@ -253,7 +242,13 @@ func readdir(dir p9.File) (p9.Dirents, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dir(%v).Open(ReadOnly) = %v, want nil (directory must be open-able to readdir)", dir, err)
 	}
-	dirents, err := dirCopy.Readdir(0, 10)
+	// TODO: add test for errno "invalid argument"
+	// The standard defines this to mean something like
+	// "requested buffer too small".
+	// We'll want to calculate the smallest possible entry size
+	// and request less than than.
+	// dirents, err := dirCopy.Readdir(offset, count)
+	dirents, err := p9.ReadDir(dirCopy)
 	if err != nil {
 		return nil, fmt.Errorf("Readdir(dir) = %v, want nil", err)
 	}

--- a/p9/p9.go
+++ b/p9/p9.go
@@ -20,6 +20,7 @@
 package p9
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"sync/atomic"
 
 	"github.com/hugelgupf/p9/internal"
+	"github.com/hugelgupf/p9/linux"
 )
 
 // Debug can be assigned to log.Printf to print messages received and sent.
@@ -1164,4 +1166,64 @@ func (d *Dirent) encode(b *buffer) {
 	b.Write64(d.Offset)
 	b.WriteQIDType(d.Type)
 	b.WriteString(d.Name)
+}
+
+// DirentSize returns the encoded
+// byte count of this entry.
+// Particularly useful when calling [File.Readdir].
+func DirentSize(name string) uint32 {
+	return direntSize(uint32(len(name)))
+}
+
+func direntSize(nameLen uint32) uint32 {
+	// 9P2000.L defines a directory entry as:
+	// qid[13] offset[8] type[1] name[s]
+	// Strings are length prefixed / Pascal strings.
+	// length[2] string[length]
+	const (
+		qid    = 13
+		offset = 8
+		typ    = 1
+		prefix = 2
+		header = qid + offset + typ + prefix
+	)
+	return header + nameLen
+}
+
+// TODO: document; full read of a directory; unsorted.
+// TODO: reconsider API. Typically my libraries take in a FID
+// and perform a whole sequence such as
+// FID -> open -> readdir -> close; where close is guaranteed on all returns.
+// The caller will typically clone the FID, pass it to our method, and not have to think about anything else.
+// The current implementation below, expects the caller to pass in an open FID and close it themselves
+// I.e. we /just/ do the read loop.
+func ReadDir(file File) (Dirents, error) {
+	var maxName uint32
+	fsinfo, err := file.StatFS()
+	if err == nil {
+		maxName = fsinfo.NameLength
+	} else if !errors.Is(err, linux.ENOSYS) {
+		return nil, err // StatFS is a bonus, not a requirement.
+	}
+	if maxName == 0 { // Fallback regardless of stat call,
+		const fallback = 255 // as `0` may represent `∞`.
+		maxName = fallback
+	}
+	const wantEntryCount = 32 // This is an estimate / request desire.
+	var (
+		maximum = direntSize(maxName)
+		count   = uint32(wantEntryCount * maximum)
+		entries Dirents
+		offset  uint64
+	)
+	for {
+		var batch Dirents
+		if batch, err = file.Readdir(offset, count); err != nil ||
+			len(batch) == 0 {
+			break
+		}
+		entries = append(entries, batch...)
+		offset = batch[len(batch)-1].Offset
+	}
+	return entries, err
 }


### PR DESCRIPTION
This builds on: #101 but for `Create`.
(I wanted to make this a dependent PR but switching the base repo+branch will create the PR in my repo I think - so this includes patchset 101 too - here is the [isolated diff](https://github.com/hugelgupf/p9/compare/5d4351f48bbbcce713ce25198d2d81275df89a85~...f080e31c7adb136441210f9e2a2b9ab25e803d1e))

This is something I think we probably want to start doing for each of the operations and common errors.
So that we can standardize the usage of portable error values in error messages across operating systems.

And I think doing it at the edges like this might make the most sense.
However, we already do some translations elsewhere in this repo, I think in the message handlers of the server implementation.
I'm not sure if we want to do it there instead of not.
Probably best at the edge like this since implementors are going to know better at these call sites - what errors to expect and how to interpret them.
If we internalize this into the server logic, we'll be responsible for interpreting any kind of error we receive.
Seems better to let the caller do it and make the server dumber / just pass through the caller's error?
Something like this.
