### PR TITLE
Fix p9/server.go race condition.

### DIFF
--- a/p9/server.go
+++ b/p9/server.go
@@ -505,7 +505,11 @@ func (cs *connState) handleRequest() bool {
 
 	// Ensure that another goroutine is available to receive from cs.t.
 	if atomic.LoadInt32(&cs.recvIdle) == 0 {
-		go cs.handleRequests() // S/R-SAFE: Irrelevant.
+		cs.pendingWg.Add(1)
+		go func() {
+			defer cs.pendingWg.Done()
+			cs.handleRequests() // S/R-SAFE: Irrelevant.
+		}()
 	}
 	cs.recvMu.Unlock()
 


### PR DESCRIPTION
I keep getting a race condition test failure (using `go test -race ./...` on my code):

```
==================                                                                                
WARNING: DATA RACE
Read at 0x00c0001ecb20 by goroutine 22:
  runtime.raceread()                
      <autogenerated>:1 +0x1e                                                                     
  github.com/hugelgupf/p9/p9.(*connState).handleRequest() 
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:473 +0x58  
  github.com/hugelgupf/p9/p9.(*connState).handleRequests()                                                                                                                                          
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:581 +0x2e   
  github.com/hugelgupf/p9/p9.(*connState).handleRequest.gowrap2()
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:508 +0xe
                                                                                                  
Previous write at 0x00c0001ecb20 by goroutine 19:         
  runtime.racewrite()                         
      <autogenerated>:1 +0x1e                                                                     
  github.com/hugelgupf/p9/p9.(*connState).stop()                                                  
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:591 +0x44
  github.com/hugelgupf/p9/p9.(*Server).Handle.deferwrap1()
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:614 +0x2e
  runtime.deferreturn()                                                                           
      /usr/lib/go-1.26/src/runtime/panic.go:668 +0x5d           
  github.com/dotwaffle/q/client.newTestClient.func1()
      /home/dotwaffle/Code/q/client/fs_test.go:21 +0x104       
                                                                                                  
Goroutine 22 (running) created at:                                                                
  github.com/hugelgupf/p9/p9.(*connState).handleRequest()
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:508 +0x3b0
  github.com/hugelgupf/p9/p9.(*connState).handleRequests()    
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:581 +0x2b3
  github.com/hugelgupf/p9/p9.(*Server).Handle()                                                   
      /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:618 +0x276
  github.com/dotwaffle/q/client.newTestClient.func1()
      /home/dotwaffle/Code/q/client/fs_test.go:21 +0x104
                                                 
Goroutine 19 (running) created at:                                                                
  github.com/dotwaffle/q/client.newTestClient()                                                   
      /home/dotwaffle/Code/q/client/fs_test.go:19 +0x18a                
  github.com/dotwaffle/q/client.TestMkdirAndUnlink()
      /home/dotwaffle/Code/q/client/fs_test.go:163 +0x54
  testing.tRunner()                         
      /usr/lib/go-1.26/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/lib/go-1.26/src/testing/testing.go:2101 +0x38
==================
panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 32 [running]:
sync.(*WaitGroup).Wait(0xc0001ecb18)
        /usr/lib/go-1.26/src/sync/waitgroup.go:213 +0x17e
github.com/hugelgupf/p9/p9.(*connState).stop(0xc0001eca90)
        /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:591 +0x45
github.com/hugelgupf/p9/p9.(*Server).Handle(0xc0001f4a00, {0x7f41fdf5ec00, 0xc0001a5280}, {0x7f41fdf5ec28, 0xc0001a5280})
        /home/dotwaffle/go/pkg/mod/github.com/hugelgupf/p9@v0.3.1-0.20260209234446-ba5af0b37df0/p9/server.go:620 +0x2c5
github.com/dotwaffle/q/client.newTestClient.func1()
        /home/dotwaffle/Code/q/client/fs_test.go:21 +0x105
created by github.com/dotwaffle/q/client.newTestClient in goroutine 26
        /home/dotwaffle/Code/q/client/fs_test.go:19 +0x18b
FAIL    github.com/dotwaffle/q/client   0.023s
```

This pull-request fixes the problem, but the comment present makes me think this may not be unintentional?