### PR TITLE
fix: don't set parent on xattr walk fidRefs

### DIFF
--- a/p9/handlers.go
+++ b/p9/handlers.go
@@ -997,7 +997,6 @@ func (t *txattrwalk) handle(cs *connState) message {
 				buf:  buf,
 			},
 			pathNode: ref.pathNode,
-			parent:   ref.parent,
 		}
 		cs.InsertFID(t.newFID, newRef)
 		return nil

--- a/p9/handlers.go
+++ b/p9/handlers.go
@@ -182,7 +182,7 @@ func (t *tremove) handle(cs *connState) message {
 	// Tunlinkat. All p9 clients will use Tunlinkat.
 	err := ref.safelyGlobal(func() error {
 		// Is this a root? Can't remove that.
-		if ref.isRoot() {
+		if ref.hasParent() {
 			return linux.EINVAL
 		}
 
@@ -627,7 +627,7 @@ func (t *trename) handle(cs *connState) message {
 
 	if err := ref.safelyGlobal(func() (err error) {
 		// Don't allow a root rename.
-		if ref.isRoot() {
+		if ref.hasParent() {
 			return linux.EINVAL
 		}
 
@@ -1203,7 +1203,7 @@ func doWalk(cs *connState, ref *fidRef, names []string, getattr bool) (qids []QI
 				mode:     ref.mode,
 				pathNode: ref.pathNode,
 			}
-			if !ref.isRoot() {
+			if !ref.hasParent() {
 				if !newRef.isDeleted() {
 					// Add only if a non-root node; the same node.
 					ref.parent.pathNode.addChild(newRef, ref.parent.pathNode.nameFor(ref))

--- a/p9/server.go
+++ b/p9/server.go
@@ -209,10 +209,10 @@ type fidRef struct {
 	// fidRef. Holding either of these locks is sufficient to examine
 	// parent safely.
 	//
-	// The parent will be nil for root fidRefs, and non-nil otherwise. The
-	// method maybeParent can be used to return a cyclical reference, and
-	// isRoot should be used to check for root over looking at parent
-	// directly.
+	// The parent will be nil for root fidRefs and pending xattrwalk/create
+	// fidRefs, and non-nil otherwise. The method maybeParent can be used
+	// to return a cyclical reference, and hasParent should be used to
+	// check for root over looking at parent directly.
 	parent *fidRef
 }
 
@@ -274,8 +274,8 @@ func (f *fidRef) isDeleted() bool {
 	return atomic.LoadUint32(&f.pathNode.deleted) != 0
 }
 
-// isRoot indicates whether this is a root fid.
-func (f *fidRef) isRoot() bool {
+// hasParent indicates whether this is a root fid.
+func (f *fidRef) hasParent() bool {
 	return f.parent == nil
 }
 


### PR DESCRIPTION
I kept on getting "bad address" (EFAULT) errors with a dynamic 9p filesystem I am building. After (a lot of) tracing, I think I've narrowed it down to this -- but I could do with some sanity checking, especially around the xattr calls behaviour which I only discovered thanks to [diod](https://github.com/chaos/diod/blob/master/protocol.md#xattrwalk---prepare-to-readlist-extended-attributes).

The txattrwalk handler created fidRefs with parent set to ref.parent but never called addChild or parent.IncRef. This caused two issues:

1. DecRef called parent.pathNode.removeChild on a ref that was never registered, triggering a spurious NOT FOUND.

2. DecRef called parent.DecRef without a matching IncRef, which could prematurely drop the parent's refcount to zero and remove other legitimately registered refs from childRefNames, leading to a panic in nameFor during clone walks.

Xattr fids are ephemeral and don't represent filesystem paths, so they should not participate in path tree tracking. Setting parent to nil (the zero value, already omitted) prevents DecRef from touching the path tree or parent ref.