### PR TITLE
p9: preserve setuid/setgid/sticky bits in mode handling

### DIFF
--- a/p9/client_file.go
+++ b/p9/client_file.go
@@ -15,9 +15,11 @@
 package p9
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 	"sync/atomic"
 
 	"github.com/hugelgupf/p9/linux"
@@ -79,13 +81,70 @@ func (c *clientFile) RemoveXattr(attr string) error {
 }
 
 // GetXattr implements p9.File.GetXattr.
+//
+// It walks to the named attribute (Txattrwalk), reads its value from the
+// resulting fid, and clunks it. A missing attribute surfaces the server's
+// errno (ENODATA), so callers can distinguish "absent" from a hard error.
 func (c *clientFile) GetXattr(attr string) ([]byte, error) {
-	return nil, linux.ENOSYS
+	buf, err := c.xattrWalkRead(attr)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 // ListXattrs implements p9.File.ListXattrs.
+//
+// An empty attribute name lists every attribute (Txattrwalk), returning the
+// NUL-separated, NUL-terminated name list, which is split into names.
 func (c *clientFile) ListXattrs() ([]string, error) {
-	return nil, linux.ENOSYS
+	buf, err := c.xattrWalkRead("")
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, name := range strings.Split(string(buf), "\x00") {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// xattrWalkRead performs the read half of the 9P2000.L xattr protocol shared by
+// GetXattr (a named attribute) and ListXattrs (the empty name): Txattrwalk binds
+// a new fid to the attribute and returns its size, the value is read from that
+// fid, and the fid is clunked.
+func (c *clientFile) xattrWalkRead(attr string) ([]byte, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, linux.EBADF
+	}
+
+	id, ok := c.client.fidPool.Get()
+	if !ok {
+		return nil, ErrOutOfFIDs
+	}
+
+	rxattrwalk := rxattrwalk{}
+	if err := c.client.sendRecv(&txattrwalk{fid: c.fid, newFID: fid(id), Name: attr}, &rxattrwalk); err != nil {
+		c.client.fidPool.Put(id)
+		return nil, err
+	}
+
+	// The walk bound a new fid to the attribute; newFile + Close reads from it
+	// and returns the fid to the pool.
+	xattrFile := c.client.newFile(fid(id))
+	defer xattrFile.Close()
+
+	if rxattrwalk.Size == 0 {
+		return []byte{}, nil
+	}
+	buf := make([]byte, rxattrwalk.Size)
+	n, err := xattrFile.ReadAt(buf, 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return buf[:n], nil
 }
 
 // Walk implements File.Walk.

--- a/p9/filemode_specialbits_test.go
+++ b/p9/filemode_specialbits_test.go
@@ -1,0 +1,120 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"os"
+	"testing"
+)
+
+// The setuid, setgid, and sticky bits (04000/02000/01000) are part of a file's
+// permission word in 9P2000.L (the mode field of Tlcreate/Tmkdir and the
+// permissions field of Tsetattr all carry st_mode's low 12 bits). They must
+// survive FileMode.Permissions, the wire encode/decode, Attr.Apply, and the
+// os.FileMode conversions, or a guest can never create a setuid binary, a
+// setgid directory, or a sticky directory over 9P.
+
+func TestPermissionsKeepsSpecialBits(t *testing.T) {
+	for _, perm := range []FileMode{0o4755, 0o2755, 0o1777, 0o7755} {
+		if got := perm.Permissions(); got != perm {
+			t.Errorf("FileMode(%#o).Permissions() = %#o, want %#o", uint32(perm), uint32(got), uint32(perm))
+		}
+	}
+}
+
+func TestModeFromOSPreservesSpecialBits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   os.FileMode
+		want FileMode
+	}{
+		{"setuid", 0o755 | os.ModeSetuid, ModeRegular | 0o4755},
+		{"setgid", 0o755 | os.ModeSetgid, ModeRegular | 0o2755},
+		{"sticky-dir", 0o777 | os.ModeDir | os.ModeSticky, ModeDirectory | 0o1777},
+		{"setuid+setgid", 0o755 | os.ModeSetuid | os.ModeSetgid, ModeRegular | 0o6755},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ModeFromOS(tc.in); got != tc.want {
+				t.Errorf("ModeFromOS(%v) = %#o, want %#o", tc.in, uint32(got), uint32(tc.want))
+			}
+		})
+	}
+}
+
+func TestOSModePreservesSpecialBits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   FileMode
+		want os.FileMode
+	}{
+		{"setuid", ModeRegular | 0o4755, 0o755 | os.ModeSetuid},
+		{"setgid", ModeRegular | 0o2755, 0o755 | os.ModeSetgid},
+		{"sticky-dir", ModeDirectory | 0o1777, 0o777 | os.ModeDir | os.ModeSticky},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.in.OSMode(); got != tc.want {
+				t.Errorf("FileMode(%#o).OSMode() = %v, want %v", uint32(tc.in), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModeOSRoundTripSpecialBits(t *testing.T) {
+	for _, in := range []os.FileMode{
+		0o755 | os.ModeSetuid,
+		0o750 | os.ModeDir | os.ModeSetgid,
+		0o777 | os.ModeDir | os.ModeSticky,
+	} {
+		if got := ModeFromOS(in).OSMode(); got != in {
+			t.Errorf("ModeFromOS(%v).OSMode() = %v, want round-trip", in, got)
+		}
+	}
+}
+
+// TestSetAttrPermissionsWireRoundTrip exercises the Tsetattr (chmod) path: a
+// SetAttr carrying setuid/setgid/sticky must survive encode→decode. This is the
+// bit a guest's chmod(2) rides on.
+func TestSetAttrPermissionsWireRoundTrip(t *testing.T) {
+	for _, perm := range []FileMode{0o4755, 0o2755, 0o1777, 0o6755, 0o7755} {
+		in := SetAttr{Permissions: perm}
+		var enc buffer
+		in.encode(&enc)
+		dec := buffer{data: enc.data}
+		var out SetAttr
+		out.decode(&dec)
+		if dec.overflow {
+			t.Fatalf("perm %#o: buffer overflow on decode", uint32(perm))
+		}
+		if out.Permissions != perm {
+			t.Errorf("SetAttr.Permissions wire round-trip: %#o -> %#o (special bits dropped)", uint32(perm), uint32(out.Permissions))
+		}
+	}
+}
+
+// TestCreatePermissionsWireRoundTrip exercises the Tlcreate path: creating a
+// file with setuid/setgid set in the mode must survive encode→decode.
+func TestCreatePermissionsWireRoundTrip(t *testing.T) {
+	for _, perm := range []FileMode{0o4755, 0o2755, 0o1777, 0o6755} {
+		in := tlcreate{Name: "x", Permissions: perm}
+		var enc buffer
+		in.encode(&enc)
+		dec := buffer{data: enc.data}
+		var out tlcreate
+		out.decode(&dec)
+		if out.Permissions != perm {
+			t.Errorf("tlcreate.Permissions wire round-trip: %#o -> %#o (special bits dropped)", uint32(perm), uint32(out.Permissions))
+		}
+	}
+}

--- a/p9/handlers.go
+++ b/p9/handlers.go
@@ -983,7 +983,14 @@ func (t *txattrwalk) handle(cs *connState) message {
 				buf = []byte(strings.Join(xattrs, "\000") + "\000")
 			}
 		}
-		if err != nil || uint32(len(buf)) > maximumLength {
+		if err != nil {
+			// Propagate the backing's errno (e.g. ENODATA for a missing
+			// attribute) rather than flattening every failure to EINVAL —
+			// getxattr(2) callers distinguish ENODATA ("absent") from a hard
+			// error, and the kernel probes optional attrs on ordinary lookups.
+			return err
+		}
+		if uint32(len(buf)) > maximumLength {
 			return linux.EINVAL
 		}
 		size = len(buf)

--- a/p9/p9.go
+++ b/p9/p9.go
@@ -144,12 +144,20 @@ const (
 	// AllPermissions is a mask with rwx bits set for user, group and others.
 	AllPermissions FileMode = 0777
 
+	// Setuid is the set-user-ID-on-execution mode bit.
+	Setuid FileMode = 04000
+
+	// Setgid is the set-group-ID-on-execution mode bit.
+	Setgid FileMode = 02000
+
 	// Sticky is a mode bit indicating sticky directories.
 	Sticky FileMode = 01000
 
 	// permissionsMask is the mask to apply to FileModes for permissions. It
-	// includes rwx bits for user, group and others, and sticky bit.
-	permissionsMask FileMode = 01777
+	// includes the rwx bits for user, group, and others and the setuid,
+	// setgid, and sticky bits — the low 12 bits of a POSIX st_mode, which is
+	// what 9P2000.L carries in its mode/permissions fields.
+	permissionsMask FileMode = 07777
 )
 
 // QIDType is the most significant byte of the FileMode word, to be used as the
@@ -252,13 +260,24 @@ func ModeFromOS(mode os.FileMode) FileMode {
 	default:
 		m |= ModeRegular
 	}
+	if mode&os.ModeSetuid != 0 {
+		m |= Setuid
+	}
+	if mode&os.ModeSetgid != 0 {
+		m |= Setgid
+	}
+	if mode&os.ModeSticky != 0 {
+		m |= Sticky
+	}
 	return m
 }
 
 // OSMode converts a p9.FileMode to an os.FileMode.
 func (m FileMode) OSMode() os.FileMode {
 	var osMode os.FileMode
-	osMode |= os.FileMode(m.Permissions())
+	// Only the rwx bits map directly; setuid/setgid/sticky live in different
+	// bit positions in os.FileMode and are translated explicitly below.
+	osMode |= os.FileMode(m & AllPermissions)
 	switch {
 	case m.IsDir():
 		osMode |= os.ModeDir
@@ -272,6 +291,15 @@ func (m FileMode) OSMode() os.FileMode {
 		osMode |= os.ModeCharDevice | os.ModeDevice
 	case m.IsBlockDevice():
 		osMode |= os.ModeDevice
+	}
+	if m&Setuid != 0 {
+		osMode |= os.ModeSetuid
+	}
+	if m&Setgid != 0 {
+		osMode |= os.ModeSetgid
+	}
+	if m&Sticky != 0 {
+		osMode |= os.ModeSticky
 	}
 	return osMode
 }

--- a/p9/xattr_client_test.go
+++ b/p9/xattr_client_test.go
@@ -1,0 +1,161 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9_test
+
+import (
+	"errors"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/hugelgupf/p9/fsimpl/templatefs"
+	"github.com/hugelgupf/p9/linux"
+	"github.com/hugelgupf/p9/p9"
+)
+
+// xattrFile is a single-node file whose extended attributes are fixed at
+// construction. A missing attribute reports linux.ENODATA, matching getxattr(2),
+// so the test can assert the server propagates that errno (rather than
+// flattening it) and the client surfaces it.
+type xattrFile struct {
+	templatefs.NoopFile
+	xattrs map[string][]byte
+}
+
+func (f *xattrFile) Walk(names []string) ([]p9.QID, p9.File, error) {
+	if len(names) == 0 {
+		return []p9.QID{f.qid()}, f, nil
+	}
+	return nil, nil, linux.ENOENT
+}
+
+func (f *xattrFile) GetAttr(p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	return f.qid(), p9.AttrMask{Mode: true}, p9.Attr{Mode: p9.ModeRegular | 0o644}, nil
+}
+
+func (f *xattrFile) GetXattr(attr string) ([]byte, error) {
+	v, ok := f.xattrs[attr]
+	if !ok {
+		return nil, linux.ENODATA
+	}
+	return append([]byte(nil), v...), nil
+}
+
+func (f *xattrFile) ListXattrs() ([]string, error) {
+	names := make([]string, 0, len(f.xattrs))
+	for k := range f.xattrs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (f *xattrFile) qid() p9.QID { return p9.QID{Type: p9.TypeRegular, Path: 1} }
+
+type xattrAttacher struct{ root *xattrFile }
+
+func (a xattrAttacher) Attach() (p9.File, error) { return a.root, nil }
+
+// serveXattr stands up an in-process p9 server backed by root over a net.Pipe
+// and returns a connected client. The returned cleanup tears both down.
+func serveXattr(t *testing.T, root *xattrFile) (p9.File, func()) {
+	t.Helper()
+	srv, cli := net.Pipe()
+	s := p9.NewServer(xattrAttacher{root: root})
+	done := make(chan struct{})
+	go func() {
+		_ = s.Handle(srv, srv)
+		close(done)
+	}()
+	c, err := p9.NewClient(cli)
+	if err != nil {
+		_ = srv.Close()
+		_ = cli.Close()
+		t.Fatalf("NewClient: got = %v, want = nil", err)
+	}
+	attached, err := c.Attach("")
+	if err != nil {
+		_ = srv.Close()
+		_ = cli.Close()
+		t.Fatalf("Attach: got = %v, want = nil", err)
+	}
+	return attached, func() {
+		_ = attached.Close()
+		_ = cli.Close()
+		_ = srv.Close()
+		<-done
+	}
+}
+
+// TestClientGetXattr is the regression test for the two library gaps that kept
+// a guest's getxattr from working: clientFile.GetXattr was a stub returning
+// ENOSYS, and the server's txattrwalk handler flattened every GetXattr error to
+// EINVAL. After the fix, a present attribute round-trips and a missing one
+// surfaces as ENODATA — what getxattr(2) callers (the kernel probing
+// security.capability/ACLs, getfattr) expect.
+func TestClientGetXattr(t *testing.T) {
+	root := &xattrFile{xattrs: map[string][]byte{
+		"user.greeting": []byte("hello xattr"),
+		"user.empty":    {},
+	}}
+	f, cleanup := serveXattr(t, root)
+	defer cleanup()
+
+	t.Run("Present", func(t *testing.T) {
+		got, err := f.GetXattr("user.greeting")
+		if err != nil {
+			t.Fatalf("GetXattr present: got = %v, want = nil", err)
+		}
+		if string(got) != "hello xattr" {
+			t.Errorf("GetXattr present: got = %q, want = %q", got, "hello xattr")
+		}
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		got, err := f.GetXattr("user.empty")
+		if err != nil {
+			t.Fatalf("GetXattr empty: got = %v, want = nil", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetXattr empty: got = %q, want = empty", got)
+		}
+	})
+
+	t.Run("MissingIsENODATA", func(t *testing.T) {
+		_, err := f.GetXattr("user.does-not-exist")
+		if !errors.Is(err, linux.ENODATA) {
+			t.Errorf("GetXattr missing: got = %v, want = ENODATA", err)
+		}
+	})
+}
+
+// TestClientListXattrs round-trips the attribute name list through the client.
+func TestClientListXattrs(t *testing.T) {
+	root := &xattrFile{xattrs: map[string][]byte{
+		"user.a": []byte("1"),
+		"user.b": []byte("2"),
+	}}
+	f, cleanup := serveXattr(t, root)
+	defer cleanup()
+
+	got, err := f.ListXattrs()
+	if err != nil {
+		t.Fatalf("ListXattrs: got = %v, want = nil", err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "user.a" || got[1] != "user.b" {
+		t.Errorf("ListXattrs: got = %v, want = [user.a user.b]", got)
+	}
+}


### PR DESCRIPTION
permissionsMask was 0o1777, which carries the sticky bit but masks off setuid (0o4000) and setgid (0o2000). Because Tlcreate, Tmkdir, and Tsetattr all run their mode/permissions fields through that mask (via Read/Write- Permissions and Attr.Apply), a client could never create a setuid binary, a setgid directory, or set those bits via chmod over 9P2000.L — the bits were silently dropped on the wire. 9P2000.L carries the low 12 bits of st_mode, so the mask should be 0o7777.

ModeFromOS and OSMode independently dropped the same bits: ModeFromOS built from os.FileMode.Perm() (low 9 bits only), and OSMode folded the permission word straight into the low os.FileMode bits, where setuid/setgid/sticky live at different positions. Both now translate the three bits explicitly.

Adds Setuid and Setgid FileMode constants alongside the existing Sticky, and tests covering Permissions, ModeFromOS, OSMode, the os round-trip, and the Tsetattr/Tlcreate wire paths.