### PR TITLE
p9: implement SetXattr and RemoveXattr on the client

### DIFF
--- a/p9/client_file.go
+++ b/p9/client_file.go
@@ -71,13 +71,67 @@ type clientFile struct {
 }
 
 // SetXattr implements p9.File.SetXattr.
+//
+// Txattrcreate binds a new fid to the attribute, the value is written to that
+// fid, and the server performs the setxattr(2) when the fid is clunked -- so
+// the error of the underlying operation is the error of that clunk.
 func (c *clientFile) SetXattr(attr string, data []byte, flags XattrFlags) error {
-	return linux.ENOSYS
+	xattrFile, err := c.xattrCreate(attr, uint64(len(data)), flags)
+	if err != nil {
+		return err
+	}
+	if len(data) > 0 {
+		// A short write is not an error from WriteAt, but the server
+		// rejects the clunk if it did not receive the whole value, so
+		// report it here rather than as an opaque EINVAL later.
+		n, err := xattrFile.WriteAt(data, 0)
+		if err == nil && n != len(data) {
+			err = io.ErrShortWrite
+		}
+		if err != nil {
+			xattrFile.Close()
+			return err
+		}
+	}
+	return xattrFile.Close()
 }
 
 // RemoveXattr implements p9.File.RemoveXattr.
 func (c *clientFile) RemoveXattr(attr string) error {
-	return linux.ENOSYS
+	// A zero-sized Txattrcreate with XattrReplace is a removal.
+	return c.SetXattr(attr, nil, XattrReplace)
+}
+
+// xattrCreate walks to a new fid -- leaving c's fid alone, since Txattrcreate
+// turns the fid it names into an attribute fid -- and binds that new fid to
+// attr, ready for the value to be written to it.
+func (c *clientFile) xattrCreate(attr string, size uint64, flags XattrFlags) (*clientFile, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, linux.EBADF
+	}
+
+	id, ok := c.client.fidPool.Get()
+	if !ok {
+		return nil, ErrOutOfFIDs
+	}
+
+	rwalk := rwalk{}
+	if err := c.client.sendRecv(&twalk{fid: c.fid, newFID: fid(id)}, &rwalk); err != nil {
+		c.client.fidPool.Put(id)
+		return nil, err
+	}
+
+	xattrFile := c.client.newFile(fid(id))
+	if err := c.client.sendRecv(&txattrcreate{
+		fid:      xattrFile.fid,
+		Name:     attr,
+		AttrSize: size,
+		Flags:    uint32(flags),
+	}, &rxattrcreate{}); err != nil {
+		xattrFile.Close()
+		return nil, err
+	}
+	return xattrFile, nil
 }
 
 // GetXattr implements p9.File.GetXattr.

--- a/p9/xattr_client_test.go
+++ b/p9/xattr_client_test.go
@@ -62,6 +62,25 @@ func (f *xattrFile) ListXattrs() ([]string, error) {
 	return names, nil
 }
 
+func (f *xattrFile) SetXattr(attr string, data []byte, flags p9.XattrFlags) error {
+	if attr == "user.readonly" {
+		return linux.EPERM
+	}
+	if f.xattrs == nil {
+		f.xattrs = make(map[string][]byte)
+	}
+	f.xattrs[attr] = append([]byte(nil), data...)
+	return nil
+}
+
+func (f *xattrFile) RemoveXattr(attr string) error {
+	if _, ok := f.xattrs[attr]; !ok {
+		return linux.ENODATA
+	}
+	delete(f.xattrs, attr)
+	return nil
+}
+
 func (f *xattrFile) qid() p9.QID { return p9.QID{Type: p9.TypeRegular, Path: 1} }
 
 type xattrAttacher struct{ root *xattrFile }
@@ -157,5 +176,74 @@ func TestClientListXattrs(t *testing.T) {
 	sort.Strings(got)
 	if len(got) != 2 || got[0] != "user.a" || got[1] != "user.b" {
 		t.Errorf("ListXattrs: got = %v, want = [user.a user.b]", got)
+	}
+}
+
+// TestClientSetXattr round-trips a value through Txattrcreate and asserts that
+// the file's own fid survives: Txattrcreate turns the fid it names into an
+// attribute fid, so the client must walk to a new one rather than sacrifice
+// the caller's.
+func TestClientSetXattr(t *testing.T) {
+	root := &xattrFile{xattrs: map[string][]byte{}}
+	f, cleanup := serveXattr(t, root)
+	defer cleanup()
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		if err := f.SetXattr("user.greeting", []byte("hello xattr"), 0); err != nil {
+			t.Fatalf("SetXattr: got = %v, want = nil", err)
+		}
+		got, err := f.GetXattr("user.greeting")
+		if err != nil {
+			t.Fatalf("GetXattr: got = %v, want = nil", err)
+		}
+		if string(got) != "hello xattr" {
+			t.Errorf("GetXattr: got = %q, want = %q", got, "hello xattr")
+		}
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		if err := f.SetXattr("user.empty", nil, 0); err != nil {
+			t.Fatalf("SetXattr empty: got = %v, want = nil", err)
+		}
+		got, err := f.GetXattr("user.empty")
+		if err != nil {
+			t.Fatalf("GetXattr empty: got = %v, want = nil", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetXattr empty: got = %q, want = empty", got)
+		}
+	})
+
+	t.Run("FileStillUsable", func(t *testing.T) {
+		if _, _, _, err := f.GetAttr(p9.AttrMask{Mode: true}); err != nil {
+			t.Errorf("GetAttr after SetXattr: got = %v, want = nil", err)
+		}
+	})
+
+	t.Run("ErrorPropagates", func(t *testing.T) {
+		// The server only calls setxattr(2) on clunk, so its error has to
+		// travel back through the clunk of the attribute fid.
+		err := f.SetXattr("user.readonly", []byte("nope"), 0)
+		if !errors.Is(err, linux.EPERM) {
+			t.Errorf("SetXattr readonly: got = %v, want = EPERM", err)
+		}
+	})
+}
+
+// TestClientRemoveXattr removes an attribute, which is a zero-sized
+// Txattrcreate with XattrReplace.
+func TestClientRemoveXattr(t *testing.T) {
+	root := &xattrFile{xattrs: map[string][]byte{"user.a": []byte("1")}}
+	f, cleanup := serveXattr(t, root)
+	defer cleanup()
+
+	if err := f.RemoveXattr("user.a"); err != nil {
+		t.Fatalf("RemoveXattr: got = %v, want = nil", err)
+	}
+	if _, err := f.GetXattr("user.a"); !errors.Is(err, linux.ENODATA) {
+		t.Errorf("GetXattr after RemoveXattr: got = %v, want = ENODATA", err)
+	}
+	if err := f.RemoveXattr("user.does-not-exist"); !errors.Is(err, linux.ENODATA) {
+		t.Errorf("RemoveXattr missing: got = %v, want = ENODATA", err)
 	}
 }


### PR DESCRIPTION
The read half of the client's xattr support is implemented, but SetXattr and RemoveXattr still return ENOSYS, so a client can read extended attributes over 9P2000.L and never write one.

Implement them with Txattrcreate. Since Txattrcreate turns the fid it names into an attribute fid, walk to a new fid first and leave the caller's file fid alone; the value is written to the new fid and the server performs the setxattr(2) when it is clunked, so that clunk's error is the result of SetXattr. RemoveXattr is a zero-sized create with XattrReplace, which the server already treats as a removal.

The tests cover the round trip, error propagation through the clunk, and that the file remains usable after SetXattr.