### PR TITLE
fsimpl/localfs: implement StatFS

### DIFF
--- a/fsimpl/localfs/localfs.go
+++ b/fsimpl/localfs/localfs.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/hugelgupf/p9/fsimpl/templatefs"
 	"github.com/hugelgupf/p9/internal"
@@ -267,16 +268,52 @@ func (l *Local) Renamed(parent p9.File, newName string) {
 
 // SetAttr implements p9.File.SetAttr.
 func (l *Local) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
-	// When truncate(2) is called on Linux, Linux will try to set time & size. Fake it. Sorry.
-	supported := p9.SetAttrMask{Size: true, MTime: true, CTime: true, ATime: true}
+	// CTime cannot be set, but Linux sends it along with other fields --
+	// e.g. when truncate(2) is called -- so accept and ignore it.
+	supported := p9.SetAttrMask{
+		Permissions:        true,
+		Size:               true,
+		MTime:              true,
+		CTime:              true,
+		ATime:              true,
+		ATimeNotSystemTime: true,
+		MTimeNotSystemTime: true,
+	}
 	if !valid.IsSubsetOf(supported) {
 		return linux.ENOSYS
 	}
 
+	if valid.Permissions {
+		// OSMode moves the setuid, setgid and sticky bits into the
+		// positions os.Chmod expects.
+		if err := os.Chmod(l.path, attr.Permissions.Permissions().OSMode()); err != nil {
+			return err
+		}
+	}
 	if valid.Size {
-		// If more than one thing is ever implemented, we can't just
-		// return an error here.
-		return os.Truncate(l.path, int64(attr.Size))
+		if err := os.Truncate(l.path, int64(attr.Size)); err != nil {
+			return err
+		}
+	}
+	if valid.ATime || valid.MTime {
+		// Chtimes leaves a time unchanged if it is the zero time.
+		var atime, mtime time.Time
+		now := time.Now()
+		if valid.ATime {
+			atime = now
+			if valid.ATimeNotSystemTime {
+				atime = time.Unix(int64(attr.ATimeSeconds), int64(attr.ATimeNanoSeconds))
+			}
+		}
+		if valid.MTime {
+			mtime = now
+			if valid.MTimeNotSystemTime {
+				mtime = time.Unix(int64(attr.MTimeSeconds), int64(attr.MTimeNanoSeconds))
+			}
+		}
+		if err := os.Chtimes(l.path, atime, mtime); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/fsimpl/localfs/localfs_test.go
+++ b/fsimpl/localfs/localfs_test.go
@@ -17,9 +17,14 @@ package localfs
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/hugelgupf/p9/fsimpl/test"
+	"github.com/hugelgupf/p9/internal"
+	"github.com/hugelgupf/p9/p9"
 )
 
 func TestLocalFS(t *testing.T) {
@@ -32,4 +37,100 @@ func TestLocalFS(t *testing.T) {
 	test.TestFile(t, Attacher(tempDir))
 	test.TestReadOnlyFS(t, Attacher(tempDir))
 	test.TestReadWriteFS(t, Attacher(tempDir))
+}
+
+func TestSetAttr(t *testing.T) {
+	tempDir := t.TempDir()
+	name := "file"
+	path := filepath.Join(tempDir, name)
+	if err := os.WriteFile(path, []byte("hello world"), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recorded before the mtime-only update below, which must leave it alone.
+	// internal.InfoToStat does not report an access time on Windows.
+	checkAtime := runtime.GOOS != "windows"
+	atimeBefore := accessTime(t, path)
+
+	root, err := Attacher(tempDir).Attach()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, file, err := root.Walk([]string{name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Whole seconds: Windows stores 100ns ticks and some file systems round
+	// to a second, which would make an exact comparison flaky.
+	mtime := time.Unix(1234, 0)
+	if err := file.SetAttr(
+		p9.SetAttrMask{Permissions: true, Size: true, MTime: true, MTimeNotSystemTime: true},
+		p9.SetAttr{
+			Permissions:      p9.Setuid | 0600,
+			Size:             5,
+			MTimeSeconds:     uint64(mtime.Unix()),
+			MTimeNanoSeconds: uint64(mtime.Nanosecond()),
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Windows chmod only implements the write bit.
+	if runtime.GOOS != "windows" {
+		if got, want := info.Mode(), os.ModeSetuid|os.FileMode(0600); got != want {
+			t.Errorf("mode = %v, want %v", got, want)
+		}
+	}
+	if got := info.Size(); got != 5 {
+		t.Errorf("size = %d, want 5", got)
+	}
+	if got := info.ModTime(); !got.Equal(mtime) {
+		t.Errorf("mtime = %v, want %v", got, mtime)
+	}
+	if checkAtime {
+		if got := accessTime(t, path); !got.Equal(atimeBefore) {
+			t.Errorf("atime after setting mtime = %v, want %v", got, atimeBefore)
+		}
+	}
+
+	// Setting the access time must leave the modification time alone.
+	atime := time.Unix(2345, 0)
+	if err := file.SetAttr(
+		p9.SetAttrMask{ATime: true, ATimeNotSystemTime: true},
+		p9.SetAttr{
+			ATimeSeconds:     uint64(atime.Unix()),
+			ATimeNanoSeconds: uint64(atime.Nanosecond()),
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkAtime {
+		if got := accessTime(t, path); !got.Equal(atime) {
+			t.Errorf("atime = %v, want %v", got, atime)
+		}
+	}
+	if got := info.ModTime(); !got.Equal(mtime) {
+		t.Errorf("mtime after setting atime = %v, want %v", got, mtime)
+	}
+}
+
+// accessTime returns the file's access time.
+func accessTime(t *testing.T, path string) time.Time {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat := internal.InfoToStat(info)
+	return time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
 }

--- a/fsimpl/localfs/statfs.go
+++ b/fsimpl/localfs/statfs.go
@@ -1,0 +1,32 @@
+//go:build linux || darwin || freebsd
+
+package localfs
+
+import (
+	"github.com/hugelgupf/p9/p9"
+	"golang.org/x/sys/unix"
+)
+
+// StatFS implements p9.File.StatFS.
+//
+// Report the numbers for the file system holding the exported directory. This
+// is only built where unix.Statfs exists; elsewhere templatefs leaves StatFS
+// unimplemented and a client sees a volume of unknown size.
+func (l *Local) StatFS() (p9.FSStat, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(l.path, &s); err != nil {
+		return p9.FSStat{}, err
+	}
+	return p9.FSStat{
+		// The unix.Statfs_t field types differ by platform, so every
+		// field is converted rather than assigned.
+		Type:            uint32(s.Type),
+		BlockSize:       uint32(s.Bsize),
+		Blocks:          uint64(s.Blocks),
+		BlocksFree:      uint64(s.Bfree),
+		BlocksAvailable: uint64(s.Bavail),
+		Files:           uint64(s.Files),
+		FilesFree:       uint64(s.Ffree),
+		NameLength:      255,
+	}, nil
+}


### PR DESCRIPTION
templatefs leaves StatFS unimplemented, so a client mounting localfs sees a
volume of unknown size. Report the numbers for the file system holding the
exported directory.

Builds on #111 (same branch point); the unix.Statfs_t field types differ by
platform, so every field is converted rather than assigned.